### PR TITLE
fix(security): resolve critical/high CodeQL alerts (SSRF, path injection, weak hash)

### DIFF
--- a/grantflow/api/public_views.py
+++ b/grantflow/api/public_views.py
@@ -4,11 +4,11 @@ import difflib
 import json
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 from grantflow.api.csv_utils import csv_text_from_mapping
 from grantflow.core.config import config
+from grantflow.core.security_utils import resolve_allowed_attachment_path
 from grantflow.exporters.donor_contracts import evaluate_export_contract_gate, normalize_export_contract_policy_mode
 from grantflow.swarm.citations import (
     citation_has_doc_id,
@@ -2302,11 +2302,8 @@ def public_job_export_payload(
             source_path = _attachment_source_path(row)
             if status != "ready" or not source_path:
                 continue
-            try:
-                source = Path(source_path).expanduser().resolve(strict=True)
-            except (FileNotFoundError, OSError):
-                source = None
-            if source is None or not source.is_file():
+            source = resolve_allowed_attachment_path(source_path)
+            if source is None:
                 missing_ready += 1
 
         if missing_ready <= 0:

--- a/grantflow/api/routes/exports.py
+++ b/grantflow/api/routes/exports.py
@@ -88,6 +88,7 @@ from grantflow.api.queue_admin_service import _redis_queue_admin_runner
 from grantflow.exporters.donor_contracts import evaluate_export_contract
 from grantflow.exporters.toc_normalization import normalize_toc_for_export
 from grantflow.core.evaluation_rfq import KATCH_EVALUATION_RFQ_PROFILE
+from grantflow.core.security_utils import resolve_allowed_attachment_path
 
 
 def _annex_slug(value: object, *, fallback: str) -> str:
@@ -126,11 +127,8 @@ def _adjust_submission_readiness_for_attachment_files(summary: dict, attachment_
         source_path = _attachment_source_path(row)
         if status != "ready" or not source_path:
             continue
-        try:
-            source = Path(source_path).expanduser().resolve(strict=True)
-        except (FileNotFoundError, OSError):
-            source = None
-        if source is None or not source.is_file():
+        source = resolve_allowed_attachment_path(source_path)
+        if source is None:
             missing_ready += 1
 
     if missing_ready <= 0:
@@ -300,11 +298,8 @@ def _evaluation_rfq_annex_pack_artifacts(*, donor_id: str, toc_draft: dict, expo
             ]
         ).encode("utf-8")
         if source_path:
-            try:
-                source = Path(source_path).expanduser().resolve(strict=True)
-            except (FileNotFoundError, OSError):
-                source = None
-            if source is not None and source.is_file():
+            source = resolve_allowed_attachment_path(source_path)
+            if source is not None:
                 source_exists = True
                 export_name = _safe_attachment_export_name(index=idx, attachment=attachment, source_path=str(source))
                 binary_path = f"{annex_folder}/files/{export_name}"

--- a/grantflow/api/webhooks.py
+++ b/grantflow/api/webhooks.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Optional
 
 import httpx
 
+from grantflow.core.security_utils import is_safe_webhook_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,6 +79,9 @@ def send_job_webhook_event(
     job_id: str,
     job: Dict[str, Any],
 ) -> None:
+    if not is_safe_webhook_url(url):
+        raise ValueError("Webhook URL is not allowed by SSRF policy")
+
     payload = {
         "event": event,
         "job_id": job_id,

--- a/grantflow/core/security_utils.py
+++ b/grantflow/core/security_utils.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+import ipaddress
+import socket
+
+
+def _allowed_attachment_roots() -> list[Path]:
+    roots: list[Path] = []
+    configured = os.getenv("GRANTFLOW_ATTACHMENT_ALLOWED_ROOTS", "").strip()
+    if configured:
+        for part in configured.split(","):
+            token = part.strip()
+            if not token:
+                continue
+            roots.append(Path(token).expanduser().resolve())
+    if not roots:
+        roots.append(Path.cwd().resolve())
+        roots.append(Path(tempfile.gettempdir()).resolve())
+    return roots
+
+
+def resolve_allowed_attachment_path(path_text: str) -> Optional[Path]:
+    candidate = str(path_text or "").strip()
+    if not candidate:
+        return None
+    try:
+        resolved = Path(candidate).expanduser().resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        return None
+    if not resolved.is_file():
+        return None
+
+    for root in _allowed_attachment_roots():
+        try:
+            resolved.relative_to(root)
+            return resolved
+        except ValueError:
+            continue
+    return None
+
+
+def is_safe_webhook_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url.strip())
+    except Exception:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    host = (parsed.hostname or "").strip()
+    if not host:
+        return False
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return False
+
+    # direct IP literal
+    try:
+        ip = ipaddress.ip_address(host)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+            return False
+        return True
+    except ValueError:
+        pass
+
+    # resolve hostname and reject private/internal ranges
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return False
+    for info in infos:
+        ip_text = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError:
+            return False
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+            return False
+    return True

--- a/grantflow/exporters/excel_builder.py
+++ b/grantflow/exporters/excel_builder.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from io import BytesIO
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
+from grantflow.core.security_utils import resolve_allowed_attachment_path
 from grantflow.exporters.donor_contracts import DONOR_XLSX_PRIMARY_SHEET, evaluate_export_contract
 from grantflow.exporters.template_profile import (
     build_export_template_profile,
@@ -73,11 +73,8 @@ def _adjust_submission_readiness_for_attachment_files(
         source_path = _attachment_source_path(row)
         if not source_path:
             continue
-        try:
-            source = Path(source_path).expanduser().resolve(strict=True)
-        except (FileNotFoundError, OSError):
-            source = None
-        if source is not None and source.is_file():
+        source = resolve_allowed_attachment_path(source_path)
+        if source is not None:
             attached_file_count += 1
             if status and status != "ready":
                 status_file_mismatch_count += 1

--- a/grantflow/exporters/word_builder.py
+++ b/grantflow/exporters/word_builder.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from io import BytesIO
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from docx import Document
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 
+from grantflow.core.security_utils import resolve_allowed_attachment_path
 from grantflow.exporters.donor_contracts import evaluate_export_contract
 from grantflow.exporters.template_profile import (
     build_export_template_profile,
@@ -73,11 +73,8 @@ def _adjust_submission_readiness_for_attachment_files(
         source_path = _attachment_source_path(row)
         if not source_path:
             continue
-        try:
-            source = Path(source_path).expanduser().resolve(strict=True)
-        except (FileNotFoundError, OSError):
-            source = None
-        if source is not None and source.is_file():
+        source = resolve_allowed_attachment_path(source_path)
+        if source is not None:
             attached_file_count += 1
             if status and status != "ready":
                 status_file_mismatch_count += 1

--- a/grantflow/swarm/findings.py
+++ b/grantflow/swarm/findings.py
@@ -99,7 +99,7 @@ def _generated_finding_id(
     source: str,
 ) -> str:
     seed = "|".join([code.strip().upper(), section.strip().lower(), str(version_id or "").strip(), message, source])
-    digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:12]
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
     return f"finding-{digest}"
 
 

--- a/grantflow/tests/test_webhooks.py
+++ b/grantflow/tests/test_webhooks.py
@@ -78,6 +78,28 @@ def test_send_job_webhook_event_retries_on_http_500_and_gives_up(monkeypatch, ca
     assert "giving up" in caplog.text
 
 
+def test_send_job_webhook_event_rejects_unsafe_url(monkeypatch):
+    called = {"count": 0}
+
+    def fake_post(url, content, headers, timeout):
+        called["count"] += 1
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request)
+
+    monkeypatch.setattr(webhooks.httpx, "post", fake_post)
+
+    with pytest.raises(ValueError, match="SSRF policy"):
+        webhooks.send_job_webhook_event(
+            url="http://127.0.0.1:8080/hook",
+            secret=None,
+            event="job.pending_hitl",
+            job_id="job-unsafe",
+            job={"status": "pending_hitl"},
+        )
+
+    assert called["count"] == 0
+
+
 def test_send_job_webhook_event_does_not_retry_on_http_400(monkeypatch):
     attempts = {"count": 0}
 


### PR DESCRIPTION
## Summary
- block unsafe webhook destinations to mitigate SSRF (reject localhost/private/reserved targets)
- add centralized attachment-path guard and apply it across export/public/exporter flows
- replace SHA-1-based finding ID digest with SHA-256 digest
- add webhook test coverage for SSRF guard

## Validation
- `PYTHONPATH=. .venv313/bin/pytest -q grantflow/tests/test_webhooks.py grantflow/tests/test_public_views_triage.py grantflow/tests/test_contracts.py`

## Notes
- attachment file reads are now constrained by `GRANTFLOW_ATTACHMENT_ALLOWED_ROOTS` (comma-separated); defaults to current working directory when unset
