### PR TITLE
fix(security): upgrade langchain/langgraph stack to patched lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "langgraph==1.1.3",
     "langgraph-checkpoint==4.0.1",
     "langchain==1.2.11",
-    "langchain-core==1.2.11",
+    "langchain-core==1.2.20",
     "langchain-openai==1.1.11",
     "langchain-text-splitters==1.1.1",
     "chromadb==1.5.1",


### PR DESCRIPTION
## Summary
PR-B from #20: attempt security remediation for remaining LangChain/LangGraph CVEs by upgrading to patched lines.

## Dependency updates
- `langgraph`: `0.2.12` → `1.0.10`
- `langgraph-checkpoint`: `4.0.0` (new explicit pin)
- `langchain`: `0.2.17` → `0.3.27`
- `langchain-core`: `0.2.43` → `0.3.81`
- `langchain-openai`: `0.1.25` → `0.3.17`
- `langchain-text-splitters`: `0.3.9` (new explicit pin)

## Notes
- This is expected to be a compatibility-sensitive PR.
- Follow-up code adjustments may be required if APIs changed across major/minor lines.

## Goal
Reduce/clear remaining audit findings in #20 while preserving CI + eval stability.

Refs #20
