### PR TITLE
chore(devx): upgrade black to 26.3.1 and apply formatter

### DIFF
--- a/grantflow/core/evaluation_rfq.py
+++ b/grantflow/core/evaluation_rfq.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterable, Literal
 
 from pydantic import BaseModel, Field
 
-
 EVALUATION_RFQ_PROPOSAL_MODE = "evaluation_rfq"
 KATCH_EVALUATION_RFQ_PROFILE = "katch_final_assessment"
 

--- a/grantflow/core/stores.py
+++ b/grantflow/core/stores.py
@@ -140,15 +140,13 @@ def open_sqlite_connection(db_path: str) -> sqlite3.Connection:
 
 
 def ensure_sqlite_schema_meta(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS schema_meta (
           component TEXT PRIMARY KEY,
           version INTEGER NOT NULL,
           updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
-        """
-    )
+        """)
 
 
 def ensure_sqlite_component_schema(conn: sqlite3.Connection, component: str, target_version: int) -> int:
@@ -315,15 +313,13 @@ class SQLiteJobStore:
     def _init_db(self) -> None:
         with self._connect() as conn:
             ensure_sqlite_component_schema(conn, self.SCHEMA_COMPONENT, self.SCHEMA_VERSION)
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS jobs (
                   job_id TEXT PRIMARY KEY,
                   payload_json TEXT NOT NULL,
                   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
-                """
-            )
+                """)
 
     def set(self, job_id: str, payload: Dict[str, Any]) -> None:
         stored_payload = prepare_job_payload_for_storage(payload)
@@ -392,8 +388,7 @@ class SQLiteIngestAuditStore:
     def _init_db(self) -> None:
         with self._connect() as conn:
             ensure_sqlite_component_schema(conn, self.SCHEMA_COMPONENT, self.SCHEMA_VERSION)
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS ingest_audit_events (
                   event_id TEXT PRIMARY KEY,
                   ts TEXT NOT NULL,
@@ -405,8 +400,7 @@ class SQLiteIngestAuditStore:
                   result_json TEXT NOT NULL,
                   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
-                """
-            )
+                """)
 
     def append(self, row: Dict[str, Any]) -> None:
         item = sanitize_jsonable(dict(row or {}))

--- a/grantflow/swarm/hitl.py
+++ b/grantflow/swarm/hitl.py
@@ -53,8 +53,7 @@ class HITLCheckpoint:
     def _init_sqlite(self) -> None:
         with self._connect() as conn:
             ensure_sqlite_component_schema(conn, self.SCHEMA_COMPONENT, self.SCHEMA_VERSION)
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS hitl_checkpoints (
                   id TEXT PRIMARY KEY,
                   stage TEXT NOT NULL,
@@ -64,8 +63,7 @@ class HITLCheckpoint:
                   state_snapshot_json TEXT NOT NULL,
                   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
-                """
-            )
+                """)
 
     def _row_to_checkpoint(self, row: sqlite3.Row) -> Dict[str, Any]:
         return {

--- a/grantflow/tests/test_exporters.py
+++ b/grantflow/tests/test_exporters.py
@@ -9,7 +9,6 @@ from grantflow.exporters.donor_contracts import evaluate_export_contract
 from grantflow.exporters.excel_builder import build_xlsx_from_logframe
 from grantflow.exporters.word_builder import build_docx_from_toc
 
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 

--- a/grantflow/tests/test_job_runner.py
+++ b/grantflow/tests/test_job_runner.py
@@ -4,7 +4,6 @@ import time
 
 from grantflow.core.job_runner import InMemoryJobRunner, RedisJobRunner
 
-
 _REDIS_TEST_OBSERVED: list[int] = []
 _REDIS_OBSERVED_LOCK = threading.Lock()
 

--- a/grantflow/tests/test_stores.py
+++ b/grantflow/tests/test_stores.py
@@ -253,15 +253,13 @@ def test_sqlite_job_store_upgrades_schema_meta_version_on_reinit(tmp_path):
     db_path = tmp_path / "grantflow_state.db"
 
     with sqlite3.connect(str(db_path)) as conn:
-        conn.execute(
-            """
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS schema_meta (
               component TEXT PRIMARY KEY,
               version INTEGER NOT NULL,
               updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
-            """
-        )
+            """)
         conn.execute(
             "INSERT INTO schema_meta (component, version) VALUES (?, ?)",
             ("jobs", 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==25.11.0",
+    "black==26.3.1",
     "isort==6.1.0",
     "ruff==0.15.2",
     "pre-commit==4.3.0",

--- a/scripts/baseline_fill_template.py
+++ b/scripts/baseline_fill_template.py
@@ -6,7 +6,6 @@ import csv
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 FIELDNAMES = [
     "case_dir",
     "preset_key",

--- a/scripts/buyer_demo_open.py
+++ b/scripts/buyer_demo_open.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 OPEN_ORDER = (
     (("latest-open-order.md",), "Opening guide"),
     (("pilot-handout.md", "pilot-handout-smoke.md"), "Single-file buyer summary"),

--- a/scripts/case_study_pack.py
+++ b/scripts/case_study_pack.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 CASE_FILES = (
     "generate-request.json",
     "generate-response.json",

--- a/scripts/clean_demo_artifacts.py
+++ b/scripts/clean_demo_artifacts.py
@@ -5,7 +5,6 @@ import argparse
 import shutil
 from pathlib import Path
 
-
 DIRECTORY_PATTERNS = (
     "demo-pack*",
     "pilot-pack*",

--- a/scripts/demo_pack.py
+++ b/scripts/demo_pack.py
@@ -13,7 +13,6 @@ from urllib.parse import urlencode
 
 from grantflow.api.public_views import _comment_triage_summary_payload
 
-
 DEFAULT_PRESET_KEYS = (
     "usaid_gov_ai_kazakhstan",
     "eu_digital_governance_moldova",

--- a/scripts/eval_ab_diff.py
+++ b/scripts/eval_ab_diff.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
-
 HIGHER_IS_BETTER_METRICS: dict[str, str] = {
     "quality_score": "quality_score",
     "critic_score": "critic_score",

--- a/scripts/executive_pack.py
+++ b/scripts/executive_pack.py
@@ -17,7 +17,6 @@ from grantflow.api.public_views import (
 )
 from toc_snapshot import build_logframe_snapshot, build_toc_snapshot
 
-
 ROOT_FILES = (
     "buyer-brief.md",
     "pilot-scorecard.md",

--- a/scripts/latest_links.py
+++ b/scripts/latest_links.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-
 LINK_SPECS = (
     ("latest-demo-pack", "demo-pack*"),
     ("latest-pilot-pack", "pilot-pack*"),

--- a/scripts/latest_open_order.py
+++ b/scripts/latest_open_order.py
@@ -6,7 +6,6 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 LINK_ORDER = (
     ("latest-diligence-index.md", "Index of all generated artifacts."),
     ("latest-executive-pack", "Primary buyer-facing bundle."),

--- a/scripts/oem_pack.py
+++ b/scripts/oem_pack.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 OEM_DOCS = (
     "docs/oem-one-pager.md",
     "docs/architecture.md",

--- a/scripts/open_latest_send.py
+++ b/scripts/open_latest_send.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 FULL_OPEN_ORDER = (
     (("latest-send-bundle-index.md", "send-bundle-index.md"), "Send bundle index"),
     (("latest-fast-send-bundle/README.md",), "Fast send bundle overview"),

--- a/scripts/pilot_benchmark_baseline.py
+++ b/scripts/pilot_benchmark_baseline.py
@@ -9,7 +9,6 @@ from math import ceil
 from pathlib import Path
 from typing import Any
 
-
 FIELDNAMES = [
     "case_dir",
     "preset_key",

--- a/scripts/pilot_scorecard.py
+++ b/scripts/pilot_scorecard.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REQUIRED_TRACE_FILES = (
     "status.json",
     "quality.json",

--- a/scripts/verify_latest_stack.py
+++ b/scripts/verify_latest_stack.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-
 REQUIRED_LINKS: dict[str, tuple[str, ...]] = {
     "latest-executive-pack": (
         "README.md",


### PR DESCRIPTION
## Summary
Maintenance PR to close the deferred `black` security item from #20.

## Changes
- `black`: `25.11.0` → `26.3.1`
- Applied formatter output on touched Python files (`grantflow/` + `scripts/`).

## Scope
- Formatting-only changes + dev dependency bump
- No functional/runtime logic changes intended

Refs #20
