### PR TITLE
chore(ci): force Node24 JS actions in supply-chain workflow

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,5 +1,8 @@
 name: Supply Chain
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
## Summary
Enable Node24-forced JavaScript action runtime in the only remaining workflow that did not set it.

## Changes
- Added:
  - `env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
- File:
  - `.github/workflows/supply-chain.yml`

## Why
Aligns Supply Chain workflow behavior with the rest of repo workflows ahead of GitHub Node20 deprecation.
