### PR TITLE
docs(governance): add P2 roadmap/checklists/templates pack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Operations runbook
+    url: https://github.com/vassiliylakhonin/grantflow/blob/main/docs/operations-runbook.md
+    about: Read operational policies and CI guardrails before opening platform/process issues.

--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,32 @@
+---
+name: Good first issue
+description: Small, well-scoped contribution task
+labels: [good-first-issue]
+---
+
+## Problem
+
+What user/developer pain does this fix?
+
+## Scope (small and explicit)
+
+- In scope:
+- Out of scope:
+
+## Acceptance Criteria
+
+- [ ] Clear behavior/result definition
+- [ ] Test or verification step documented
+- [ ] Docs updated (if user/operator visible)
+
+## Suggested Implementation Notes
+
+- Files/modules likely touched:
+- Risks/edge cases:
+
+## Validation
+
+- [ ] `ruff` clean
+- [ ] `black` clean
+- [ ] `mypy` clean (if applicable)
+- [ ] targeted `pytest` (or explain why not)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,13 @@
 - [ ] `black` clean
 - [ ] `mypy` clean (targeted baseline)
 
+## Quality & Risk Checklist
+
+- [ ] Eval delta reviewed (if eval/quality-sensitive area changed)
+- [ ] Security impact reviewed (deps/auth/data handling)
+- [ ] Performance impact reviewed (latency/throughput path)
+- [ ] API/contract impact reviewed (OpenAPI / payload compatibility)
+
 ## Changelog
 
 - [ ] `CHANGELOG.md` updated (or not needed, explain below)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ See:
 - `docs/architecture.md`
 - `docs/contributor-map.md`
 - `docs/api-stability-policy.md`
+- `docs/public-roadmap.md`
+- `docs/coverage-threshold-policy.md`
 
 **Security / Enterprise Review**
 - `docs/enterprise-access-layer.md`

--- a/docs/coverage-threshold-policy.md
+++ b/docs/coverage-threshold-policy.md
@@ -1,0 +1,25 @@
+# Coverage Threshold Policy
+
+This repository uses a **pragmatic threshold policy** focused on core-path confidence over vanity percentages.
+
+## Policy
+
+- Do not merge changes that reduce confidence on critical paths without compensating tests.
+- For changes touching core pipeline/API/export logic, add or update targeted tests.
+- Use contract tests + integration smoke + eval suites as the primary confidence stack.
+
+## Threshold Direction
+
+- Baseline target: maintain or improve effective coverage on critical modules.
+- Hard global numeric fail-under is deferred until coverage collection is fully deterministic in CI for all suites.
+
+## Merge Gate Expectations (current)
+
+- CI test jobs must pass.
+- Contract guards must pass.
+- Quality/eval guards must pass.
+- For risky changes, include explicit test evidence in PR summary.
+
+## Future Tightening (planned)
+
+- Introduce module-level thresholds for core packages once stable coverage telemetry is consistently available in CI artifacts.

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -199,3 +199,12 @@ Guard scope:
 - Required `200 application/json` response schemas on key public operations.
 
 Goal: catch accidental API contract drift early without relying on full integration runtime.
+
+## 10) P2 Governance Defaults
+
+Repository governance defaults now include:
+
+- Public roadmap: `docs/public-roadmap.md`
+- Good-first-issue template: `.github/ISSUE_TEMPLATE/good-first-issue.md`
+- PR quality checklist: `.github/pull_request_template.md` (eval delta, security impact, performance impact, API contract impact)
+- Coverage policy: `docs/coverage-threshold-policy.md`

--- a/docs/public-roadmap.md
+++ b/docs/public-roadmap.md
@@ -1,0 +1,37 @@
+# Public Roadmap
+
+This roadmap is intentionally lightweight and outcome-focused.
+
+## Now (0-4 weeks)
+
+- Stabilize CI governance hardening (quality gates, API contracts, reproducibility).
+- Keep nightly grounded evaluation actionable (triage ownership + drift discipline).
+- Tighten operator docs for pilot readiness.
+
+## Next (1-2 months)
+
+- Expand contract-test coverage for critical API and export surfaces.
+- Improve benchmark representativeness for grounded smoke/perf checks.
+- Reduce CI warning noise and close remaining Node runtime migration gaps.
+
+## Later (2-3 months)
+
+- Broader multi-tenant operational hardening.
+- Stronger evidence packaging for pilot conversions.
+- Contributor onboarding improvements and narrower first-contribution paths.
+
+## Good First Issues
+
+Use label: `good-first-issue`.
+
+Good candidates are tasks that:
+- touch one area only,
+- have clear acceptance criteria,
+- are testable in local CI,
+- do not require production credentials.
+
+Starter categories:
+- docs clarity and runbook quality
+- small contract tests
+- CI observability/reporting improvements
+- deterministic tooling helpers


### PR DESCRIPTION
## Summary
Implements P2 governance pack to make project status and contribution flow clearer.

## Included
- Public roadmap: `docs/public-roadmap.md`
- Good-first-issue template: `.github/ISSUE_TEMPLATE/good-first-issue.md`
- Issue template config: `.github/ISSUE_TEMPLATE/config.yml`
- PR quality checklist upgrade in `.github/pull_request_template.md`:
  - eval delta
  - security impact
  - performance impact
  - API contract impact
- Coverage policy: `docs/coverage-threshold-policy.md`
- Ops runbook + README references updated.

## Why
Closes remaining P2 governance gaps:
- roadmap visibility
- newcomer entry points
- higher-signal PR reviews
- explicit coverage policy
