### PR TITLE
feat(api): persist bid/no-bid decision in job quality payload

### DIFF
--- a/docs/release-note-2026-03-19.md
+++ b/docs/release-note-2026-03-19.md
@@ -1,0 +1,49 @@
+# Release Note — 2026-03-19
+
+## Summary
+This release cycle focused on engineering hardening: CI quality governance, security remediation, dependency reproducibility, performance guardrails, API contract checks, and contribution governance.
+
+## What shipped
+
+### 1) Quality gate hardening
+- Nightly grounded-tail gate now splits regressions by severity:
+  - hard-fail metrics
+  - warn-only metrics
+- Added clearer gate summary output for triage.
+- Added auto-triage issue creation on repeated nightly failures.
+
+### 2) Security and supply-chain improvements
+- Added supply-chain workflow with:
+  - `pip-audit`
+  - CycloneDX SBOM artifact generation
+- Remediated dependency vulnerabilities in runtime-critical packages.
+- Completed deferred formatter-security maintenance (`black` upgrade + format pass).
+
+### 3) Reproducibility improvements
+- Introduced hash-locked dependency snapshots:
+  - `requirements.lock`
+  - `requirements-dev.lock`
+- CI supply-chain scanning now runs against deterministic lockfile inputs.
+
+### 4) Performance guardrails
+- Added grounded smoke performance budget gate in CI:
+  - latency budget
+  - throughput budget
+- Added benchmark timing and performance summary artifacts for triage.
+
+### 5) API compatibility guard
+- Added lightweight OpenAPI contract guard in CI for critical paths/methods/security scheme/schema expectations.
+- Wired into `dependency-contract` job for fast compatibility drift detection.
+
+### 6) Documentation and governance updates
+- README refreshed for clearer positioning and current-state accuracy.
+- Added public roadmap: `docs/public-roadmap.md`.
+- Added coverage policy: `docs/coverage-threshold-policy.md`.
+- Added `good-first-issue` template and issue template config.
+- Upgraded PR template with quality/risk checklist (eval, security, performance, API impact).
+
+## Result
+- CI signal quality improved (fewer false blockers, better triage paths).
+- Security posture improved with explicit scanning and remediation.
+- Dependency and scan behavior became more deterministic.
+- Governance baseline now clearer for maintainers and contributors.

--- a/grantflow/api/bid_no_bid.py
+++ b/grantflow/api/bid_no_bid.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "strategic_fit": 0.18,
+    "win_probability": 0.18,
+    "budget_margin": 0.12,
+    "delivery_capacity": 0.14,
+    "compliance_readiness": 0.14,
+    "partner_strength": 0.08,
+    "timeline_realism": 0.08,
+    "evidence_strength": 0.08,
+}
+
+CRITERIA_ORDER: tuple[str, ...] = tuple(DEFAULT_WEIGHTS.keys())
+
+RISK_HINTS: dict[str, str] = {
+    "strategic_fit": "Clarify donor fit, priorities, and comparative advantage before bidding.",
+    "win_probability": "Rebuild win strategy and competitor differentiation with concrete evidence.",
+    "budget_margin": "Rework commercial model and scope to restore healthy margin.",
+    "delivery_capacity": "Confirm staffing plan, surge capacity, and delivery ownership.",
+    "compliance_readiness": "Close eligibility/compliance gaps and validate mandatory requirements.",
+    "partner_strength": "Strengthen consortium roles and secure partner commitments.",
+    "timeline_realism": "Rebaseline timeline and submission workplan with realistic milestones.",
+    "evidence_strength": "Improve proof points, references, and measurable past-performance evidence.",
+}
+
+
+def _normalized_weights(weight_overrides: dict[str, float] | None) -> dict[str, float]:
+    if not weight_overrides:
+        return dict(DEFAULT_WEIGHTS)
+
+    merged = dict(DEFAULT_WEIGHTS)
+    for key, value in weight_overrides.items():
+        if key in merged and float(value) > 0:
+            merged[key] = float(value)
+
+    total = sum(merged.values())
+    if total <= 0:
+        return dict(DEFAULT_WEIGHTS)
+    return {key: value / total for key, value in merged.items()}
+
+
+def evaluate_bid_no_bid(
+    *,
+    scores: dict[str, int],
+    weight_overrides: dict[str, float] | None = None,
+    mandatory_eligibility_gap: bool = False,
+    conflict_of_interest: bool = False,
+) -> dict[str, Any]:
+    weights = _normalized_weights(weight_overrides)
+
+    weighted_score = 0.0
+    for key in CRITERIA_ORDER:
+        weighted_score += float(scores.get(key, 0)) * weights[key]
+
+    hard_blockers: list[str] = []
+    if mandatory_eligibility_gap:
+        hard_blockers.append("mandatory_eligibility_gap")
+    if conflict_of_interest:
+        hard_blockers.append("conflict_of_interest")
+
+    if scores.get("compliance_readiness", 0) < 40:
+        hard_blockers.append("critical_compliance_readiness")
+    if scores.get("delivery_capacity", 0) < 35:
+        hard_blockers.append("critical_delivery_capacity")
+
+    low_signals = sorted(
+        (
+            {"criterion": key, "score": int(scores.get(key, 0)), "weight": round(weights[key], 4)}
+            for key in CRITERIA_ORDER
+            if int(scores.get(key, 0)) < 60
+        ),
+        key=lambda row: (row["score"], -row["weight"]),
+    )
+
+    must_fix_before_bid = []
+    for row in low_signals[:3]:
+        criterion = str(row["criterion"])
+        must_fix_before_bid.append(
+            {
+                "criterion": criterion,
+                "current_score": int(row["score"]),
+                "target_score": 70,
+                "action": RISK_HINTS.get(criterion, "Raise this signal before bid commitment."),
+            }
+        )
+
+    if hard_blockers:
+        verdict = "NO_BID"
+    elif weighted_score >= 70 and len(low_signals) <= 1:
+        verdict = "BID"
+    elif weighted_score >= 55:
+        verdict = "CONDITIONAL_BID"
+    else:
+        verdict = "NO_BID"
+
+    top_risks = [
+        {
+            "criterion": str(row["criterion"]),
+            "score": int(row["score"]),
+            "risk_level": "high" if int(row["score"]) < 45 else "medium",
+        }
+        for row in low_signals[:3]
+    ]
+
+    return {
+        "weighted_score": round(weighted_score, 2),
+        "verdict": verdict,
+        "hard_blockers": hard_blockers,
+        "top_risks": top_risks,
+        "must_fix_before_bid": must_fix_before_bid,
+        "weights": {key: round(weights[key], 4) for key in CRITERIA_ORDER},
+    }

--- a/grantflow/api/bid_no_bid.py
+++ b/grantflow/api/bid_no_bid.py
@@ -67,21 +67,16 @@ def evaluate_bid_no_bid(
         hard_blockers.append("critical_delivery_capacity")
 
     low_signals = sorted(
-        (
-            {"criterion": key, "score": int(scores.get(key, 0)), "weight": round(weights[key], 4)}
-            for key in CRITERIA_ORDER
-            if int(scores.get(key, 0)) < 60
-        ),
-        key=lambda row: (row["score"], -row["weight"]),
+        ((key, int(scores.get(key, 0)), float(weights[key])) for key in CRITERIA_ORDER if int(scores.get(key, 0)) < 60),
+        key=lambda row: (row[1], -row[2]),
     )
 
     must_fix_before_bid = []
-    for row in low_signals[:3]:
-        criterion = str(row["criterion"])
+    for criterion, current_score, _weight in low_signals[:3]:
         must_fix_before_bid.append(
             {
                 "criterion": criterion,
-                "current_score": int(row["score"]),
+                "current_score": current_score,
                 "target_score": 70,
                 "action": RISK_HINTS.get(criterion, "Raise this signal before bid commitment."),
             }
@@ -98,11 +93,11 @@ def evaluate_bid_no_bid(
 
     top_risks = [
         {
-            "criterion": str(row["criterion"]),
-            "score": int(row["score"]),
-            "risk_level": "high" if int(row["score"]) < 45 else "medium",
+            "criterion": criterion,
+            "score": score,
+            "risk_level": "high" if score < 45 else "medium",
         }
-        for row in low_signals[:3]
+        for criterion, score, _weight in low_signals[:3]
     ]
 
     return {

--- a/grantflow/api/public_views.py
+++ b/grantflow/api/public_views.py
@@ -4035,6 +4035,7 @@ def public_job_quality_payload(
         "time_to_first_draft_seconds": sanitize_for_public_response(metrics_payload.get("time_to_first_draft_seconds")),
         "time_to_terminal_seconds": sanitize_for_public_response(metrics_payload.get("time_to_terminal_seconds")),
         "grounding_trust_summary": sanitize_for_public_response(trust_summary),
+        "bid_no_bid_decision": sanitize_for_public_response(state_dict.get("bid_no_bid_decision")),
         "critic": {
             "engine": sanitize_for_public_response(critic_payload.get("engine")),
             "rule_score": sanitize_for_public_response(critic_payload.get("rule_score")),

--- a/grantflow/api/routes/jobs.py
+++ b/grantflow/api/routes/jobs.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import BackgroundTasks, HTTPException, Query, Request
 
+from grantflow.api.bid_no_bid import evaluate_bid_no_bid
 from grantflow.api.idempotency_store_facade import (
     _get_job,
     _ingest_inventory,
@@ -44,6 +45,8 @@ from grantflow.api.public_views import (
 )
 from grantflow.api.presets_service import _dispatch_generate_from_preset, _resolve_preflight_request_context
 from grantflow.api.schemas import (
+    BidNoBidRequest,
+    BidNoBidResponse,
     GenerateAcceptedPublicResponse,
     GenerateFromPresetAcceptedPublicResponse,
     GenerateFromPresetBatchRequest,
@@ -743,6 +746,55 @@ def get_status_quality(job_id: str, request: Request):
     donor = _job_donor_id(job)
     inventory_rows = _ingest_inventory(donor_id=donor or None, tenant_id=job_tenant_id)
     return public_job_quality_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+
+
+@jobs_router.post(
+    "/status/{job_id}/decision/bid-no-bid",
+    response_model=BidNoBidResponse,
+    response_model_exclude_none=True,
+)
+def post_status_bid_no_bid_decision(job_id: str, payload: BidNoBidRequest, request: Request):
+    require_api_key_if_configured(request)
+    job = _get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    _ensure_job_tenant_write_access(request, job)
+
+    scores = {
+        "strategic_fit": payload.strategic_fit,
+        "win_probability": payload.win_probability,
+        "budget_margin": payload.budget_margin,
+        "delivery_capacity": payload.delivery_capacity,
+        "compliance_readiness": payload.compliance_readiness,
+        "partner_strength": payload.partner_strength,
+        "timeline_realism": payload.timeline_realism,
+        "evidence_strength": payload.evidence_strength,
+    }
+
+    invalid_fields = [key for key, value in scores.items() if int(value) < 0 or int(value) > 100]
+    if invalid_fields:
+        raise HTTPException(status_code=400, detail=f"Scores must be between 0 and 100: {', '.join(invalid_fields)}")
+
+    decision = evaluate_bid_no_bid(
+        scores=scores,
+        weight_overrides=payload.weight_overrides,
+        mandatory_eligibility_gap=payload.mandatory_eligibility_gap,
+        conflict_of_interest=payload.conflict_of_interest,
+    )
+
+    state_dict = job.get("state") if isinstance(job.get("state"), dict) else {}
+    next_state = dict(state_dict)
+    next_state["bid_no_bid_decision"] = {
+        **decision,
+        "inputs": {
+            "scores": scores,
+            "mandatory_eligibility_gap": bool(payload.mandatory_eligibility_gap),
+            "conflict_of_interest": bool(payload.conflict_of_interest),
+        },
+    }
+    _update_job(job_id, state=next_state)
+
+    return decision
 
 
 @jobs_router.get(

--- a/grantflow/api/routes/system.py
+++ b/grantflow/api/routes/system.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 
+from grantflow.api.bid_no_bid import evaluate_bid_no_bid
 from grantflow.api.diagnostics_service import _health_diagnostics
 from grantflow.api.readiness_service import _build_readiness_payload
 from grantflow.api.routers import system_router
+from grantflow.api.schemas import BidNoBidRequest, BidNoBidResponse
 from grantflow.core.version import __version__
 
 
@@ -23,3 +25,28 @@ def readiness_check():
     if str(payload.get("status") or "").strip().lower() != "ready":
         raise HTTPException(status_code=503, detail=payload)
     return payload
+
+
+@system_router.post("/decision/bid-no-bid", response_model=BidNoBidResponse)
+def bid_no_bid_decision(payload: BidNoBidRequest):
+    scores = {
+        "strategic_fit": payload.strategic_fit,
+        "win_probability": payload.win_probability,
+        "budget_margin": payload.budget_margin,
+        "delivery_capacity": payload.delivery_capacity,
+        "compliance_readiness": payload.compliance_readiness,
+        "partner_strength": payload.partner_strength,
+        "timeline_realism": payload.timeline_realism,
+        "evidence_strength": payload.evidence_strength,
+    }
+
+    invalid_fields = [key for key, value in scores.items() if int(value) < 0 or int(value) > 100]
+    if invalid_fields:
+        raise HTTPException(status_code=400, detail=f"Scores must be between 0 and 100: {', '.join(invalid_fields)}")
+
+    return evaluate_bid_no_bid(
+        scores=scores,
+        weight_overrides=payload.weight_overrides,
+        mandatory_eligibility_gap=payload.mandatory_eligibility_gap,
+        conflict_of_interest=payload.conflict_of_interest,
+    )

--- a/grantflow/api/schemas.py
+++ b/grantflow/api/schemas.py
@@ -141,6 +141,33 @@ class ReviewWorkflowSLARecomputeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class BidNoBidRequest(BaseModel):
+    strategic_fit: int
+    win_probability: int
+    budget_margin: int
+    delivery_capacity: int
+    compliance_readiness: int
+    partner_strength: int
+    timeline_realism: int
+    evidence_strength: int
+    weight_overrides: Optional[Dict[str, float]] = None
+    mandatory_eligibility_gap: bool = False
+    conflict_of_interest: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BidNoBidResponse(BaseModel):
+    weighted_score: float
+    verdict: Literal["BID", "CONDITIONAL_BID", "NO_BID"]
+    hard_blockers: list[str]
+    top_risks: list[Dict[str, Any]]
+    must_fix_before_bid: list[Dict[str, Any]]
+    weights: Dict[str, float]
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class JobStatusPublicResponse(BaseModel):
     status: str
     state: Optional[Dict[str, Any]] = None

--- a/grantflow/tests/test_bid_no_bid.py
+++ b/grantflow/tests/test_bid_no_bid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from grantflow.api.app import app
+from grantflow.api.idempotency_store_facade import _set_job
 
 
 def _base_payload() -> dict[str, int]:
@@ -70,3 +71,31 @@ def test_bid_no_bid_rejects_invalid_score_range() -> None:
 
     assert response.status_code == 400
     assert "Scores must be between 0 and 100" in str(response.json())
+
+
+def test_job_scoped_bid_no_bid_persists_to_quality_payload() -> None:
+    client = TestClient(app)
+    job_id = "job-bid-no-bid-persist"
+    _set_job(
+        job_id,
+        {
+            "status": "done",
+            "state": {},
+            "hitl_enabled": False,
+            "donor_id": "eu",
+            "tenant_id": "tenant_demo",
+        },
+    )
+
+    decision_response = client.post(f"/status/{job_id}/decision/bid-no-bid", json=_base_payload())
+    assert decision_response.status_code == 200
+    decision_payload = decision_response.json()
+    assert decision_payload["verdict"] in {"BID", "CONDITIONAL_BID", "NO_BID"}
+
+    quality_response = client.get(f"/status/{job_id}/quality")
+    assert quality_response.status_code == 200
+    quality_payload = quality_response.json()
+    stored_decision = quality_payload.get("bid_no_bid_decision")
+    assert isinstance(stored_decision, dict)
+    assert stored_decision.get("verdict") == decision_payload.get("verdict")
+    assert isinstance(stored_decision.get("inputs"), dict)

--- a/grantflow/tests/test_bid_no_bid.py
+++ b/grantflow/tests/test_bid_no_bid.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from grantflow.api.app import app
+
+
+def _base_payload() -> dict[str, int]:
+    return {
+        "strategic_fit": 80,
+        "win_probability": 75,
+        "budget_margin": 70,
+        "delivery_capacity": 78,
+        "compliance_readiness": 82,
+        "partner_strength": 68,
+        "timeline_realism": 72,
+        "evidence_strength": 74,
+    }
+
+
+def test_bid_no_bid_returns_bid_for_strong_profile() -> None:
+    client = TestClient(app)
+    response = client.post("/decision/bid-no-bid", json=_base_payload())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["verdict"] == "BID"
+    assert payload["weighted_score"] >= 70
+    assert payload["hard_blockers"] == []
+
+
+def test_bid_no_bid_returns_conditional_bid_for_mid_profile() -> None:
+    client = TestClient(app)
+    request_payload = {
+        **_base_payload(),
+        "win_probability": 58,
+        "budget_margin": 55,
+        "partner_strength": 50,
+        "evidence_strength": 52,
+    }
+    response = client.post("/decision/bid-no-bid", json=request_payload)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["verdict"] == "CONDITIONAL_BID"
+    assert len(payload["must_fix_before_bid"]) >= 1
+
+
+def test_bid_no_bid_returns_no_bid_on_hard_blocker() -> None:
+    client = TestClient(app)
+    request_payload = {
+        **_base_payload(),
+        "mandatory_eligibility_gap": True,
+    }
+    response = client.post("/decision/bid-no-bid", json=request_payload)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["verdict"] == "NO_BID"
+    assert "mandatory_eligibility_gap" in payload["hard_blockers"]
+
+
+def test_bid_no_bid_rejects_invalid_score_range() -> None:
+    client = TestClient(app)
+    request_payload = {
+        **_base_payload(),
+        "win_probability": 140,
+    }
+    response = client.post("/decision/bid-no-bid", json=request_payload)
+
+    assert response.status_code == 400
+    assert "Scores must be between 0 and 100" in str(response.json())


### PR DESCRIPTION
## Summary
Bid/No-Bid v2: persist job-scoped decisions in job state and expose them in `/status/{job_id}/quality`.

## Changes
- New endpoint:
  - `POST /status/{job_id}/decision/bid-no-bid`
  - computes decision with existing scorecard logic
  - stores decision under `state.bid_no_bid_decision`
- Quality payload now includes:
  - `bid_no_bid_decision`
- Tests:
  - job-scoped decision write
  - quality payload includes stored decision

## Why
Makes Bid/No-Bid operational: decision is attached to the job record and visible in quality/status workflows, not just returned ad-hoc.
