### PR TITLE
feat(api): add donor presets for bid/no-bid scoring weights

### DIFF
--- a/grantflow/api/bid_no_bid.py
+++ b/grantflow/api/bid_no_bid.py
@@ -13,6 +13,49 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "evidence_strength": 0.08,
 }
 
+DONOR_WEIGHT_PRESETS: dict[str, dict[str, float]] = {
+    "usaid": {
+        "strategic_fit": 0.2,
+        "win_probability": 0.16,
+        "budget_margin": 0.1,
+        "delivery_capacity": 0.14,
+        "compliance_readiness": 0.18,
+        "partner_strength": 0.06,
+        "timeline_realism": 0.06,
+        "evidence_strength": 0.1,
+    },
+    "eu": {
+        "strategic_fit": 0.16,
+        "win_probability": 0.16,
+        "budget_margin": 0.12,
+        "delivery_capacity": 0.14,
+        "compliance_readiness": 0.14,
+        "partner_strength": 0.1,
+        "timeline_realism": 0.08,
+        "evidence_strength": 0.1,
+    },
+    "un": {
+        "strategic_fit": 0.17,
+        "win_probability": 0.15,
+        "budget_margin": 0.1,
+        "delivery_capacity": 0.15,
+        "compliance_readiness": 0.14,
+        "partner_strength": 0.12,
+        "timeline_realism": 0.07,
+        "evidence_strength": 0.1,
+    },
+    "giz": {
+        "strategic_fit": 0.18,
+        "win_probability": 0.16,
+        "budget_margin": 0.11,
+        "delivery_capacity": 0.14,
+        "compliance_readiness": 0.16,
+        "partner_strength": 0.08,
+        "timeline_realism": 0.07,
+        "evidence_strength": 0.1,
+    },
+}
+
 CRITERIA_ORDER: tuple[str, ...] = tuple(DEFAULT_WEIGHTS.keys())
 
 RISK_HINTS: dict[str, str] = {
@@ -27,29 +70,40 @@ RISK_HINTS: dict[str, str] = {
 }
 
 
-def _normalized_weights(weight_overrides: dict[str, float] | None) -> dict[str, float]:
-    if not weight_overrides:
-        return dict(DEFAULT_WEIGHTS)
+def _normalized_weights(
+    weight_overrides: dict[str, float] | None,
+    donor_profile: str | None = None,
+) -> tuple[dict[str, float], str | None]:
+    profile_key = str(donor_profile or "").strip().lower() or None
+    preset = DONOR_WEIGHT_PRESETS.get(profile_key or "")
 
-    merged = dict(DEFAULT_WEIGHTS)
+    if not weight_overrides:
+        base = dict(preset or DEFAULT_WEIGHTS)
+        total = sum(base.values())
+        if total <= 0:
+            return dict(DEFAULT_WEIGHTS), None
+        return ({key: value / total for key, value in base.items()}, profile_key if preset else None)
+
+    merged = dict(preset or DEFAULT_WEIGHTS)
     for key, value in weight_overrides.items():
         if key in merged and float(value) > 0:
             merged[key] = float(value)
 
     total = sum(merged.values())
     if total <= 0:
-        return dict(DEFAULT_WEIGHTS)
-    return {key: value / total for key, value in merged.items()}
+        return dict(DEFAULT_WEIGHTS), None
+    return ({key: value / total for key, value in merged.items()}, profile_key if preset else None)
 
 
 def evaluate_bid_no_bid(
     *,
     scores: dict[str, int],
     weight_overrides: dict[str, float] | None = None,
+    donor_profile: str | None = None,
     mandatory_eligibility_gap: bool = False,
     conflict_of_interest: bool = False,
 ) -> dict[str, Any]:
-    weights = _normalized_weights(weight_overrides)
+    weights, preset_profile = _normalized_weights(weight_overrides, donor_profile=donor_profile)
 
     weighted_score = 0.0
     for key in CRITERIA_ORDER:
@@ -107,4 +161,5 @@ def evaluate_bid_no_bid(
         "top_risks": top_risks,
         "must_fix_before_bid": must_fix_before_bid,
         "weights": {key: round(weights[key], 4) for key in CRITERIA_ORDER},
+        "preset_profile": preset_profile,
     }

--- a/grantflow/api/routes/jobs.py
+++ b/grantflow/api/routes/jobs.py
@@ -777,6 +777,7 @@ def post_status_bid_no_bid_decision(job_id: str, payload: BidNoBidRequest, reque
 
     decision = evaluate_bid_no_bid(
         scores=scores,
+        donor_profile=payload.donor_profile,
         weight_overrides=payload.weight_overrides,
         mandatory_eligibility_gap=payload.mandatory_eligibility_gap,
         conflict_of_interest=payload.conflict_of_interest,
@@ -788,6 +789,7 @@ def post_status_bid_no_bid_decision(job_id: str, payload: BidNoBidRequest, reque
         **decision,
         "inputs": {
             "scores": scores,
+            "donor_profile": payload.donor_profile,
             "mandatory_eligibility_gap": bool(payload.mandatory_eligibility_gap),
             "conflict_of_interest": bool(payload.conflict_of_interest),
         },

--- a/grantflow/api/routes/system.py
+++ b/grantflow/api/routes/system.py
@@ -46,6 +46,7 @@ def bid_no_bid_decision(payload: BidNoBidRequest):
 
     return evaluate_bid_no_bid(
         scores=scores,
+        donor_profile=payload.donor_profile,
         weight_overrides=payload.weight_overrides,
         mandatory_eligibility_gap=payload.mandatory_eligibility_gap,
         conflict_of_interest=payload.conflict_of_interest,

--- a/grantflow/api/schemas.py
+++ b/grantflow/api/schemas.py
@@ -150,6 +150,7 @@ class BidNoBidRequest(BaseModel):
     partner_strength: int
     timeline_realism: int
     evidence_strength: int
+    donor_profile: Optional[Literal["usaid", "eu", "un", "giz"]] = None
     weight_overrides: Optional[Dict[str, float]] = None
     mandatory_eligibility_gap: bool = False
     conflict_of_interest: bool = False
@@ -164,6 +165,7 @@ class BidNoBidResponse(BaseModel):
     top_risks: list[Dict[str, Any]]
     must_fix_before_bid: list[Dict[str, Any]]
     weights: Dict[str, float]
+    preset_profile: Optional[str] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/grantflow/tests/test_bid_no_bid.py
+++ b/grantflow/tests/test_bid_no_bid.py
@@ -30,6 +30,16 @@ def test_bid_no_bid_returns_bid_for_strong_profile() -> None:
     assert payload["hard_blockers"] == []
 
 
+def test_bid_no_bid_applies_donor_preset_when_requested() -> None:
+    client = TestClient(app)
+    response = client.post("/decision/bid-no-bid", json={**_base_payload(), "donor_profile": "usaid"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["preset_profile"] == "usaid"
+    assert payload["weights"]["compliance_readiness"] >= 0.17
+
+
 def test_bid_no_bid_returns_conditional_bid_for_mid_profile() -> None:
     client = TestClient(app)
     request_payload = {
@@ -87,7 +97,10 @@ def test_job_scoped_bid_no_bid_persists_to_quality_payload() -> None:
         },
     )
 
-    decision_response = client.post(f"/status/{job_id}/decision/bid-no-bid", json=_base_payload())
+    decision_response = client.post(
+        f"/status/{job_id}/decision/bid-no-bid",
+        json={**_base_payload(), "donor_profile": "eu"},
+    )
     assert decision_response.status_code == 200
     decision_payload = decision_response.json()
     assert decision_payload["verdict"] in {"BID", "CONDITIONAL_BID", "NO_BID"}
@@ -99,3 +112,4 @@ def test_job_scoped_bid_no_bid_persists_to_quality_payload() -> None:
     assert isinstance(stored_decision, dict)
     assert stored_decision.get("verdict") == decision_payload.get("verdict")
     assert isinstance(stored_decision.get("inputs"), dict)
+    assert stored_decision["inputs"].get("donor_profile") == "eu"


### PR DESCRIPTION
## Summary
Add donor-specific weight presets for Bid/No-Bid scoring so teams can avoid manual weighting on each decision.

## Changes
- Added donor weight presets in `grantflow/api/bid_no_bid.py`:
  - `usaid`, `eu`, `un`, `giz`
- `BidNoBidRequest` now accepts:
  - `donor_profile` (`usaid|eu|un|giz`)
- `BidNoBidResponse` now returns:
  - `preset_profile` (applied preset or null)
- Applied preset support in both endpoints:
  - `POST /decision/bid-no-bid`
  - `POST /status/{job_id}/decision/bid-no-bid`
- Persisted donor profile input in job-scoped stored decision.
- Added/updated tests for preset application + persistence.

## Behavior
- If `donor_profile` is provided and known, preset weights are used as base.
- `weight_overrides` still work and override preset values.
- Weights are normalized after merge.
