### PR TITLE
feat(eu): runtime safeguarding annex generation + critic readiness checks

### DIFF
--- a/grantflow/swarm/critic_donor_policy.py
+++ b/grantflow/swarm/critic_donor_policy.py
@@ -211,6 +211,57 @@ def apply_donor_specific_toc_checks(
                 message="EU ToC is missing expected outcomes, so the intervention logic cannot yet show measurable downstream change.",
                 fix_hint="Add `expected_outcomes[]` entries with measurable expected change so the EU package shows a clear path from specific objectives to outcome evidence and verification.",
             )
+
+        annex = toc_payload.get("safeguarding_annex")
+        if isinstance(annex, list) and any(str(item).strip() for item in annex):
+            check_fn(
+                code="EU_SAFEGUARDING_ANNEX_PRESENT",
+                status="pass",
+                section="toc",
+                detail=f"{len([x for x in annex if str(x).strip()])} annex item(s)",
+            )
+            annex_text = " ".join(str(item).lower() for item in annex if str(item).strip())
+            required_blocks = {
+                "protocol": any(token in annex_text for token in ("protocol", "do-no-harm", "survivor")),
+                "referral": any(token in annex_text for token in ("referral", "escalation", "handoff")),
+                "owner": any(token in annex_text for token in ("owner", "ownership", "focal point")),
+                "compliance": any(token in annex_text for token in ("compliance", "checkpoint", "evidence")),
+            }
+            missing_blocks = [k for k, ok in required_blocks.items() if not ok]
+            if missing_blocks:
+                check_fn(
+                    code="EU_SAFEGUARDING_ANNEX_MINIMUM_BLOCKS",
+                    status="warn",
+                    section="toc",
+                    detail=f"Missing blocks: {', '.join(missing_blocks)}",
+                )
+                add_flaw_fn(
+                    code="EU_SAFEGUARDING_ANNEX_INCOMPLETE",
+                    severity="medium",
+                    section="toc",
+                    message="EU safeguarding annex is present but incomplete for readiness review.",
+                    fix_hint="Ensure annex covers protocol, referral/escalation, named risk owner, and compliance checkpoint blocks.",
+                )
+            else:
+                check_fn(
+                    code="EU_SAFEGUARDING_ANNEX_MINIMUM_BLOCKS",
+                    status="pass",
+                    section="toc",
+                )
+        else:
+            check_fn(
+                code="EU_SAFEGUARDING_ANNEX_PRESENT",
+                status="warn",
+                section="toc",
+                detail="No safeguarding_annex",
+            )
+            add_flaw_fn(
+                code="EU_SAFEGUARDING_ANNEX_MISSING",
+                severity="medium",
+                section="toc",
+                message="EU ToC is missing a safeguarding annex needed for partner risk and compliance review.",
+                fix_hint="Add `safeguarding_annex[]` with protocol, referral/escalation, risk owner, and compliance checkpoint details.",
+            )
         return
 
     if donor == "giz":

--- a/grantflow/swarm/nodes/architect_generation.py
+++ b/grantflow/swarm/nodes/architect_generation.py
@@ -711,8 +711,33 @@ def _fallback_structured_toc(
         depth=0,
         evidence_hint=evidence_hint,
     )
+    if str(donor_id or "").strip().lower() == "eu" and isinstance(payload, dict):
+        payload = _ensure_eu_safeguarding_annex(payload, project=project, country=country)
     return payload, "contract_synthesizer"
 
+
+
+
+def _default_eu_safeguarding_annex(project: str, country: str) -> list[str]:
+    country_name = str(country or "target country").strip()
+    project_label = str(project or "programme").strip()
+    return [
+        f"Safeguarding protocol for {project_label} in {country_name}: prevention, incident intake, confidentiality, survivor-centered support.",
+        "Referral and escalation pathway: focal point roles, 24h escalation trigger, and partner-to-authority handoff protocol.",
+        "Risk ownership matrix: named owner per safeguarding risk, weekly review cadence, and mitigation tracking log.",
+        "EU compliance checkpoint: verify do-no-harm controls, consent records, and annex evidence completeness before submission.",
+    ]
+
+
+def _ensure_eu_safeguarding_annex(payload: Dict[str, Any], *, project: str, country: str) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return payload
+    existing = payload.get("safeguarding_annex")
+    if isinstance(existing, list) and any(str(item).strip() for item in existing):
+        return payload
+    enriched = dict(payload)
+    enriched["safeguarding_annex"] = _default_eu_safeguarding_annex(project, country)
+    return enriched
 
 def _llm_structured_toc(
     schema_cls: Type[BaseModel],
@@ -1512,6 +1537,9 @@ def generate_toc_under_contract(
             engine = f"deterministic:{synth_engine}"
             fallback_class = "deterministic_mode"
         model = None
+
+    if donor_id.strip().lower() == "eu" and isinstance(raw_payload, dict):
+        raw_payload = _ensure_eu_safeguarding_annex(raw_payload, project=project, country=country)
 
     if model is None:
         model = _model_validate(schema_cls, raw_payload)

--- a/grantflow/swarm/nodes/architect_generation.py
+++ b/grantflow/swarm/nodes/architect_generation.py
@@ -716,8 +716,6 @@ def _fallback_structured_toc(
     return payload, "contract_synthesizer"
 
 
-
-
 def _default_eu_safeguarding_annex(project: str, country: str) -> list[str]:
     country_name = str(country or "target country").strip()
     project_label = str(project or "programme").strip()
@@ -732,12 +730,42 @@ def _default_eu_safeguarding_annex(project: str, country: str) -> list[str]:
 def _ensure_eu_safeguarding_annex(payload: Dict[str, Any], *, project: str, country: str) -> Dict[str, Any]:
     if not isinstance(payload, dict):
         return payload
+
+    defaults = _default_eu_safeguarding_annex(project, country)
     existing = payload.get("safeguarding_annex")
-    if isinstance(existing, list) and any(str(item).strip() for item in existing):
+    existing_items = [str(item).strip() for item in existing] if isinstance(existing, list) else []
+    existing_items = [item for item in existing_items if item]
+
+    if not existing_items:
+        enriched = dict(payload)
+        enriched["safeguarding_annex"] = defaults
+        return enriched
+
+    annex_text = " ".join(existing_items).lower()
+    required_blocks = {
+        "protocol": any(token in annex_text for token in ("protocol", "do-no-harm", "survivor")),
+        "referral": any(token in annex_text for token in ("referral", "escalation", "handoff")),
+        "owner": any(token in annex_text for token in ("owner", "ownership", "focal point")),
+        "compliance": any(token in annex_text for token in ("compliance", "checkpoint", "evidence")),
+    }
+    if all(required_blocks.values()):
         return payload
+
+    missing_defaults: list[str] = []
+    if not required_blocks["protocol"]:
+        missing_defaults.append(defaults[0])
+    if not required_blocks["referral"]:
+        missing_defaults.append(defaults[1])
+    if not required_blocks["owner"]:
+        missing_defaults.append(defaults[2])
+    if not required_blocks["compliance"]:
+        missing_defaults.append(defaults[3])
+
+    merged = existing_items + [item for item in missing_defaults if item not in existing_items]
     enriched = dict(payload)
-    enriched["safeguarding_annex"] = _default_eu_safeguarding_annex(project, country)
+    enriched["safeguarding_annex"] = merged
     return enriched
+
 
 def _llm_structured_toc(
     schema_cls: Type[BaseModel],

--- a/grantflow/tests/test_architect.py
+++ b/grantflow/tests/test_architect.py
@@ -876,6 +876,8 @@ def test_fallback_structured_toc_uses_eu_specific_intervention_logic_phrasing():
     assert any("institutional capacity" in row["title"].lower() for row in payload["specific_objectives"])
     assert payload["expected_outcomes"]
     assert any("measurable improvements" in row["expected_change"].lower() for row in payload["expected_outcomes"])
+    assert payload["safeguarding_annex"]
+    assert len([row for row in payload["safeguarding_annex"] if str(row).strip()]) >= 1
 
 
 def test_fallback_structured_toc_uses_worldbank_specific_results_chain_phrasing():

--- a/grantflow/tests/test_critic_donor_policy.py
+++ b/grantflow/tests/test_critic_donor_policy.py
@@ -113,11 +113,19 @@ def test_eu_complete_payload_passes_new_structure_checks():
                 "expected_change": "15% increase in formal credit uptake",
             }
         ],
+        "safeguarding_annex": [
+            "Safeguarding protocol with do-no-harm and survivor-centered safeguards",
+            "Referral and escalation pathway with handoff steps",
+            "Risk owner matrix with named focal points",
+            "Compliance checkpoint and evidence verification before submission",
+        ],
     }
     checks, flaws = _run_policy("eu", toc_payload)
     assert any(c["code"] == "EU_OVERALL_OBJECTIVE_COMPLETE" and c["status"] == "pass" for c in checks)
     assert any(c["code"] == "EU_SPECIFIC_OBJECTIVES_COMPLETE" and c["status"] == "pass" for c in checks)
     assert any(c["code"] == "EU_EXPECTED_OUTCOMES_PRESENT" and c["status"] == "pass" for c in checks)
+    assert any(c["code"] == "EU_SAFEGUARDING_ANNEX_PRESENT" and c["status"] == "pass" for c in checks)
+    assert any(c["code"] == "EU_SAFEGUARDING_ANNEX_MINIMUM_BLOCKS" and c["status"] == "pass" for c in checks)
     assert not any(f["severity"] == "high" for f in flaws)
 
 
@@ -161,6 +169,19 @@ def test_eu_missing_overall_objective_uses_intervention_logic_language():
     flaw = next(f for f in flaws if f["code"] == "EU_OVERALL_OBJECTIVE_MISSING")
     assert "credible top-line anchor" in flaw["message"].lower()
     assert "verification logic" in flaw["fix_hint"].lower()
+
+
+def test_eu_missing_safeguarding_annex_emits_readiness_flaw():
+    _checks, flaws = _run_policy(
+        "eu",
+        {
+            "overall_objective": {"objective_id": "OO1", "title": "T", "rationale": "R"},
+            "specific_objectives": [{"objective_id": "SO1", "title": "T", "rationale": "R"}],
+            "expected_outcomes": [{"outcome_id": "OUT1", "title": "T", "expected_change": "C"}],
+        },
+    )
+    flaw = next(f for f in flaws if f["code"] == "EU_SAFEGUARDING_ANNEX_MISSING")
+    assert "safeguarding annex" in flaw["message"].lower()
 
 
 def test_worldbank_missing_results_chain_uses_framework_review_language():


### PR DESCRIPTION
## What
- Adds runtime EU safeguarding annex enrichment in architect generation flow (not export-only).
- Ensures fallback structured ToC for EU includes safeguarding annex content.
- Adds critic policy checks for EU safeguarding annex presence + minimum readiness blocks:
  - protocol
  - referral/escalation
  - risk owner
  - compliance checkpoint

## Why
Follow-up to #57 and #56: make EU donor payload review-ready upstream in generation pipeline.

## Tests
- `PYTHONPATH=/Users/vassiliylakhonin/.openclaw/workspace/grantflow .venv313/bin/pytest -q grantflow/tests/test_architect.py -k "fallback_structured_toc_uses_eu_specific_intervention_logic_phrasing"`
- `PYTHONPATH=/Users/vassiliylakhonin/.openclaw/workspace/grantflow .venv313/bin/pytest -q grantflow/tests/test_critic_donor_policy.py -k "eu_complete_payload_passes_new_structure_checks or eu_missing_safeguarding_annex_emits_readiness_flaw"`

Closes #57
