### PR TITLE
feat(demo+ops): export drill-down action and pilot go/no-go quickcheck

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,7 @@ If you are new to the project, read in this order:
 ## 7) Pilot toolkit (active)
 
 - `pilot-day1-checklist.md`
+- `pilot-go-no-go-quickcheck.md`
 - `pilot-evaluation-checklist.md`
 - `pilot-kickoff-agenda.md`
 - `pilot-proof-outreach-template.md`

--- a/docs/pilot-go-no-go-quickcheck.md
+++ b/docs/pilot-go-no-go-quickcheck.md
@@ -1,0 +1,63 @@
+# Pilot Go/No-Go Quickcheck (5-minute gate)
+
+Use this right before demo or pilot handoff.
+
+## 1) Runtime up and healthy
+
+```bash
+make pilot-stack-check
+```
+
+Expected:
+- `/health` returns 200
+- `/ready` returns 200
+
+## 2) Fast engineering gate
+
+```bash
+make qa-fast
+```
+
+Expected:
+- tests pass
+- `qa-hitl` pass
+- mypy clean
+
+## 3) Demo chain works end-to-end
+
+```bash
+make ci-demo-smoke
+```
+
+Expected:
+- smoke artifacts created
+- no blocker in summary
+
+## 4) Export contract/readiness visible
+
+```bash
+curl -s http://127.0.0.1:8000/status/<JOB_ID>/quality | jq '.export_contract.submission_readiness_summary'
+```
+
+Expected:
+- `readiness_status` present (`ready|partial|weak|missing`)
+- `completeness_score` present
+- `top_gap` present
+
+## 5) Reviewer flow check
+
+```bash
+curl -s http://127.0.0.1:8000/status/<JOB_ID>/review/workflow | jq '.summary'
+```
+
+Expected:
+- workflow summary present
+- no unexpected stale/overdue spike before demo
+
+---
+
+## Decision rule
+
+- **Go**: steps 1-3 pass, and steps 4-5 show expected structured output.
+- **Conditional Go**: steps 1-3 pass but step 4 or 5 shows manageable warnings with owner/date.
+- **No-Go**: step 1, 2, or 3 fails.

--- a/grantflow/api/demo_ui.py
+++ b/grantflow/api/demo_ui.py
@@ -409,6 +409,7 @@ def render_demo_ui_html() -> str:
           <div class="body">
             <div class="row">
               <button id="qualityBtn" class="ghost">Load Quality Summary</button>
+              <button id="qualityOpenExportPayloadBtn" class="ghost">Open Export Payload</button>
               <div class="sub" style="align-self:center;">Critic + citations + architect policy summary for reviewer triage.</div>
             </div>
             <div class="kpis" id="qualityCards" style="margin-top:10px;">
@@ -1224,7 +1225,7 @@ def render_demo_ui_html() -> str:
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="exportPayloadCard">
           <h2>Export Payload</h2>
           <div class="body">
             <div class="row">
@@ -1963,6 +1964,7 @@ def render_demo_ui_html() -> str:
         portfolioReviewWorkflowTrendsJson: $("portfolioReviewWorkflowTrendsJson"),
         portfolioReviewWorkflowSlaTrendsJson: $("portfolioReviewWorkflowSlaTrendsJson"),
         criticJson: $("criticJson"),
+        exportPayloadCard: $("exportPayloadCard"),
         exportPayloadJson: $("exportPayloadJson"),
         exportContractPill: $("exportContractPill"),
         exportContractPillText: $("exportContractPillText"),
@@ -2198,6 +2200,7 @@ def render_demo_ui_html() -> str:
         criticBulkApplyBtn: $("criticBulkApplyBtn"),
         criticBulkClearFiltersBtn: $("criticBulkClearFiltersBtn"),
         qualityBtn: $("qualityBtn"),
+        qualityOpenExportPayloadBtn: $("qualityOpenExportPayloadBtn"),
         portfolioBtn: $("portfolioBtn"),
         portfolioReviewWorkflowBtn: $("portfolioReviewWorkflowBtn"),
         portfolioReviewWorkflowSlaBtn: $("portfolioReviewWorkflowSlaBtn"),
@@ -8054,6 +8057,16 @@ def render_demo_ui_html() -> str:
         return body;
       }
 
+      async function openExportPayloadFromQuality() {
+        const jobId = currentJobId();
+        if (!jobId) throw new Error("No job_id");
+        await refreshExportPayload();
+        const target = els.exportPayloadCard || document.getElementById("exportPayloadCard");
+        if (target && typeof target.scrollIntoView === "function") {
+          target.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      }
+
       function applyPortfolioDonorFilter(donorKey) {
         els.portfolioDonorFilter.value = donorKey || "";
         persistUiState();
@@ -9788,6 +9801,9 @@ def render_demo_ui_html() -> str:
           }
         });
         els.qualityBtn.addEventListener("click", () => refreshQuality().catch(showError));
+        els.qualityOpenExportPayloadBtn?.addEventListener("click", () =>
+          openExportPayloadFromQuality().catch(showError)
+        );
         els.workerHeartbeatBtn.addEventListener("click", () => refreshWorkerHeartbeat().catch(showError));
         els.workerHeartbeatPollToggleBtn.addEventListener("click", toggleWorkerHeartbeatPolling);
         els.workerHeartbeatPollSeconds.addEventListener("change", onWorkerHeartbeatPollIntervalChange);

--- a/grantflow/tests/test_demo_ui_triage_smoke.py
+++ b/grantflow/tests/test_demo_ui_triage_smoke.py
@@ -11,6 +11,11 @@ def test_demo_ui_contains_triage_power_controls_and_telemetry_hooks():
     assert 'id="reviewWorkflowKpiLine"' in html
     assert 'id="reviewWorkflowSloLine"' in html
     assert 'id="downloadTriageOpsReportBtn"' in html
+    assert 'id="qualityOpenExportPayloadBtn"' in html
+    assert 'id="exportPayloadCard"' in html
+    assert 'Export readiness' in html
+    assert 'Export score' in html
+    assert 'Export top gap' in html
 
     # keyboard shortcuts, telemetry persistence, KPI/SLO/report hooks
     assert "function handleTriageShortcut(event)" in html


### PR DESCRIPTION
## Summary
- add `Open Export Payload` action in Demo Quality panel (one-click drill-down)
- add anchorable Export Payload card target and smooth scroll behavior
- add pilot quick gate doc: `docs/pilot-go-no-go-quickcheck.md` (5 command checks)
- link quickcheck doc in docs map
- extend demo UI smoke test to lock new export-readiness UI controls

## Why
You asked for bigger, product-forward batches. This bundles UX + operator workflow + guardrail test in one change.

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_demo_ui_triage_smoke.py -q`
