### PR TITLE
feat(demo+ops): one-click pilot quick report + quickcheck artifacts

### DIFF
--- a/docs/pilot-go-no-go-quickcheck.md
+++ b/docs/pilot-go-no-go-quickcheck.md
@@ -8,6 +8,10 @@ One-command option:
 make pilot-quickcheck
 ```
 
+Artifacts:
+- `build/pilot-quickcheck/report.json`
+- `build/pilot-quickcheck/report.md`
+
 ## 1) Runtime up and healthy
 
 ```bash

--- a/grantflow/api/demo_ui.py
+++ b/grantflow/api/demo_ui.py
@@ -410,6 +410,7 @@ def render_demo_ui_html() -> str:
             <div class="row">
               <button id="qualityBtn" class="ghost">Load Quality Summary</button>
               <button id="qualityOpenExportPayloadBtn" class="ghost">Open Export Payload</button>
+              <button id="downloadPilotQuickReportBtn" class="ghost">Download Pilot Quick Report</button>
               <div class="sub" style="align-self:center;">Critic + citations + architect policy summary for reviewer triage.</div>
             </div>
             <div class="kpis" id="qualityCards" style="margin-top:10px;">
@@ -2201,6 +2202,7 @@ def render_demo_ui_html() -> str:
         criticBulkClearFiltersBtn: $("criticBulkClearFiltersBtn"),
         qualityBtn: $("qualityBtn"),
         qualityOpenExportPayloadBtn: $("qualityOpenExportPayloadBtn"),
+        downloadPilotQuickReportBtn: $("downloadPilotQuickReportBtn"),
         portfolioBtn: $("portfolioBtn"),
         portfolioReviewWorkflowBtn: $("portfolioReviewWorkflowBtn"),
         portfolioReviewWorkflowSlaBtn: $("portfolioReviewWorkflowSlaBtn"),
@@ -8067,6 +8069,72 @@ def render_demo_ui_html() -> str:
         }
       }
 
+      function buildPilotQuickReportMarkdown(report) {
+        const lines = [];
+        lines.push("# Pilot Quick Report");
+        lines.push("");
+        lines.push(`- generated_at: ${String(report.generated_at || "-")}`);
+        lines.push(`- job_id: ${String(report.job_id || "-")}`);
+        lines.push("");
+        lines.push("## Runtime");
+        lines.push(`- api_base: ${String(report.api_base || "-")}`);
+        lines.push(`- terminal_status: ${String(report.terminal_status || "-")}`);
+        lines.push("");
+        lines.push("## Quality");
+        lines.push(`- quality_score: ${String(report.quality_score ?? "-")}`);
+        lines.push(`- critic_score: ${String(report.critic_score ?? "-")}`);
+        lines.push(`- grounded_trust_score: ${String(report.grounded_trust_score ?? "-")}`);
+        lines.push("");
+        lines.push("## Export readiness");
+        lines.push(`- readiness_status: ${String(report.export_readiness_status || "-")}`);
+        lines.push(`- completeness_score: ${String(report.export_completeness_score ?? "-")}`);
+        lines.push(`- top_gap: ${String(report.export_top_gap || "-")}`);
+        lines.push("");
+        lines.push("## Workflow");
+        lines.push(`- summary_present: ${String(Boolean(report.review_workflow_summary_present))}`);
+        return lines.join("\n");
+      }
+
+      async function downloadPilotQuickReport() {
+        const jobId = currentJobId();
+        if (!jobId) throw new Error("No job_id");
+        const [quality, metrics, exportPayload, workflow] = await Promise.all([
+          refreshQuality(),
+          refreshMetrics(),
+          refreshExportPayload(),
+          refreshReviewWorkflow(),
+        ]);
+        const qualityRoot = quality && typeof quality === "object" ? quality : {};
+        const metricsRoot = metrics && typeof metrics === "object" ? metrics : {};
+        const payloadRoot = exportPayload && typeof exportPayload === "object" ? (exportPayload.payload || {}) : {};
+        const readiness = payloadRoot && typeof payloadRoot === "object"
+          ? (payloadRoot.submission_package_readiness || {})
+          : {};
+        const workflowRoot = workflow && typeof workflow === "object" ? workflow : {};
+        const report = {
+          generated_at: new Date().toISOString(),
+          api_base: apiBase(),
+          job_id: jobId,
+          terminal_status: metricsRoot.terminal_status || null,
+          quality_score: qualityRoot.quality_score ?? null,
+          critic_score: qualityRoot.critic_score ?? null,
+          grounded_trust_score:
+            (metricsRoot.grounding_trust_summary && metricsRoot.grounding_trust_summary.score)
+            ?? (qualityRoot.grounding_trust_summary && qualityRoot.grounding_trust_summary.score)
+            ?? null,
+          export_readiness_status: readiness.readiness_status || null,
+          export_completeness_score: readiness.completeness_score ?? null,
+          export_top_gap: readiness.top_gap || null,
+          review_workflow_summary_present: Boolean(workflowRoot.summary && typeof workflowRoot.summary === "object"),
+        };
+        const dateSuffix = new Date().toISOString().slice(0, 10);
+        const jsonBlob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+        downloadBlob(jsonBlob, `pilot_quick_report_${jobId}_${dateSuffix}.json`);
+        const markdown = buildPilotQuickReportMarkdown(report);
+        const mdBlob = new Blob([markdown], { type: "text/markdown" });
+        downloadBlob(mdBlob, `pilot_quick_report_${jobId}_${dateSuffix}.md`);
+      }
+
       function applyPortfolioDonorFilter(donorKey) {
         els.portfolioDonorFilter.value = donorKey || "";
         persistUiState();
@@ -9803,6 +9871,9 @@ def render_demo_ui_html() -> str:
         els.qualityBtn.addEventListener("click", () => refreshQuality().catch(showError));
         els.qualityOpenExportPayloadBtn?.addEventListener("click", () =>
           openExportPayloadFromQuality().catch(showError)
+        );
+        els.downloadPilotQuickReportBtn?.addEventListener("click", () =>
+          downloadPilotQuickReport().catch(showError)
         );
         els.workerHeartbeatBtn.addEventListener("click", () => refreshWorkerHeartbeat().catch(showError));
         els.workerHeartbeatPollToggleBtn.addEventListener("click", toggleWorkerHeartbeatPolling);

--- a/grantflow/tests/test_demo_ui_triage_smoke.py
+++ b/grantflow/tests/test_demo_ui_triage_smoke.py
@@ -12,6 +12,7 @@ def test_demo_ui_contains_triage_power_controls_and_telemetry_hooks():
     assert 'id="reviewWorkflowSloLine"' in html
     assert 'id="downloadTriageOpsReportBtn"' in html
     assert 'id="qualityOpenExportPayloadBtn"' in html
+    assert 'id="downloadPilotQuickReportBtn"' in html
     assert 'id="exportPayloadCard"' in html
     assert 'Export readiness' in html
     assert 'Export score' in html

--- a/scripts/pilot_quickcheck.sh
+++ b/scripts/pilot_quickcheck.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 API_BASE="${API_BASE:-http://127.0.0.1:8000}"
 JOB_ID="${JOB_ID:-}"
+REPORT_DIR="${REPORT_DIR:-build/pilot-quickcheck}"
+REPORT_JSON="$REPORT_DIR/report.json"
+REPORT_MD="$REPORT_DIR/report.md"
+
+mkdir -p "$REPORT_DIR"
 
 printf "[1/4] Health check: %s\n" "$API_BASE"
 curl -fsS "$API_BASE/health" >/dev/null
@@ -14,10 +19,93 @@ make qa-fast >/dev/null
 printf "[3/4] Demo smoke artifacts\n"
 make ci-demo-smoke >/dev/null
 
+python3 - "$API_BASE" "$JOB_ID" "$REPORT_JSON" "$REPORT_MD" <<'PY'
+import json
+import pathlib
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+api_base, job_id, report_json_path, report_md_path = sys.argv[1:5]
+
+report = {
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "api_base": api_base,
+    "job_id": job_id or None,
+    "checks": {
+        "health": "pass",
+        "ready": "pass",
+        "qa_fast": "pass",
+        "ci_demo_smoke": "pass",
+    },
+}
+
+if job_id:
+    def fetch_json(url: str):
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    quality = fetch_json(f"{api_base}/status/{job_id}/quality")
+    metrics = fetch_json(f"{api_base}/status/{job_id}/metrics")
+    export_payload = fetch_json(f"{api_base}/status/{job_id}/export-payload")
+    workflow = fetch_json(f"{api_base}/status/{job_id}/review/workflow")
+
+    readiness = ((export_payload.get("payload") or {}).get("submission_package_readiness") or {})
+    report["checks"]["job_contract"] = "pass"
+    report["terminal_status"] = metrics.get("terminal_status")
+    report["quality"] = {
+        "quality_score": quality.get("quality_score"),
+        "critic_score": quality.get("critic_score"),
+        "grounded_trust_score": ((metrics.get("grounding_trust_summary") or {}).get("score")),
+    }
+    report["export_readiness"] = {
+        "readiness_status": readiness.get("readiness_status"),
+        "completeness_score": readiness.get("completeness_score"),
+        "top_gap": readiness.get("top_gap"),
+    }
+    report["workflow"] = {
+        "summary_present": isinstance(workflow.get("summary"), dict),
+    }
+
+lines = [
+    "# Pilot Quickcheck Report",
+    "",
+    f"- generated_at: {report.get('generated_at')}",
+    f"- api_base: {api_base}",
+    f"- job_id: {job_id or '-'}",
+    "",
+    "## Checks",
+]
+for key, value in (report.get("checks") or {}).items():
+    lines.append(f"- {key}: {value}")
+
+if job_id:
+    lines.extend(
+        [
+            "",
+            "## Quality",
+            f"- quality_score: {(report.get('quality') or {}).get('quality_score')}",
+            f"- critic_score: {(report.get('quality') or {}).get('critic_score')}",
+            f"- grounded_trust_score: {(report.get('quality') or {}).get('grounded_trust_score')}",
+            "",
+            "## Export readiness",
+            f"- readiness_status: {(report.get('export_readiness') or {}).get('readiness_status')}",
+            f"- completeness_score: {(report.get('export_readiness') or {}).get('completeness_score')}",
+            f"- top_gap: {(report.get('export_readiness') or {}).get('top_gap')}",
+            "",
+            "## Workflow",
+            f"- summary_present: {(report.get('workflow') or {}).get('summary_present')}",
+        ]
+    )
+
+pathlib.Path(report_json_path).write_text(json.dumps(report, indent=2), encoding="utf-8")
+pathlib.Path(report_md_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
 if [[ -n "$JOB_ID" ]]; then
   printf "[4/4] Job contract spot-check for %s\n" "$JOB_ID"
   curl -fsS "$API_BASE/status/$JOB_ID/quality" | python3 -c 'import json,sys;d=json.load(sys.stdin);s=((d.get("export_contract") or {}).get("submission_readiness_summary") or {});assert s.get("readiness_status") in {"ready","partial","weak","missing"};print("quality_ok")' >/dev/null
   curl -fsS "$API_BASE/status/$JOB_ID/review/workflow" | python3 -c 'import json,sys;d=json.load(sys.stdin);assert isinstance(d.get("summary"),dict);print("workflow_ok")' >/dev/null
 fi
 
-echo "pilot_quickcheck: PASS"
+echo "pilot_quickcheck: PASS ($REPORT_JSON, $REPORT_MD)"


### PR DESCRIPTION
## Summary
- add Demo button: `Download Pilot Quick Report` in Quality Summary
- produce two downloadable files from Demo UI in one click:
  - `pilot_quick_report_<job>_<date>.json`
  - `pilot_quick_report_<job>_<date>.md`
- enrich `scripts/pilot_quickcheck.sh` to generate report artifacts:
  - `build/pilot-quickcheck/report.json`
  - `build/pilot-quickcheck/report.md`
- document artifact paths in pilot quickcheck doc
- extend demo UI smoke test with new button id

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_demo_ui_triage_smoke.py -q`

Note: local `pilot_quickcheck.sh` runtime check needs a live API on `127.0.0.1:8000`.
