### PR TITLE
feat(demo+api): pilot quick report endpoint + single-call UI download

### DIFF
--- a/grantflow/api/demo_ui.py
+++ b/grantflow/api/demo_ui.py
@@ -8098,39 +8098,12 @@ def render_demo_ui_html() -> str:
       async function downloadPilotQuickReport() {
         const jobId = currentJobId();
         if (!jobId) throw new Error("No job_id");
-        const [quality, metrics, exportPayload, workflow] = await Promise.all([
-          refreshQuality(),
-          refreshMetrics(),
-          refreshExportPayload(),
-          refreshReviewWorkflow(),
-        ]);
-        const qualityRoot = quality && typeof quality === "object" ? quality : {};
-        const metricsRoot = metrics && typeof metrics === "object" ? metrics : {};
-        const payloadRoot = exportPayload && typeof exportPayload === "object" ? (exportPayload.payload || {}) : {};
-        const readiness = payloadRoot && typeof payloadRoot === "object"
-          ? (payloadRoot.submission_package_readiness || {})
-          : {};
-        const workflowRoot = workflow && typeof workflow === "object" ? workflow : {};
-        const report = {
-          generated_at: new Date().toISOString(),
-          api_base: apiBase(),
-          job_id: jobId,
-          terminal_status: metricsRoot.terminal_status || null,
-          quality_score: qualityRoot.quality_score ?? null,
-          critic_score: qualityRoot.critic_score ?? null,
-          grounded_trust_score:
-            (metricsRoot.grounding_trust_summary && metricsRoot.grounding_trust_summary.score)
-            ?? (qualityRoot.grounding_trust_summary && qualityRoot.grounding_trust_summary.score)
-            ?? null,
-          export_readiness_status: readiness.readiness_status || null,
-          export_completeness_score: readiness.completeness_score ?? null,
-          export_top_gap: readiness.top_gap || null,
-          review_workflow_summary_present: Boolean(workflowRoot.summary && typeof workflowRoot.summary === "object"),
-        };
+        const report = await apiFetch(`/status/${encodeURIComponent(jobId)}/pilot-quick-report`);
+        const reportRoot = report && typeof report === "object" ? report : {};
         const dateSuffix = new Date().toISOString().slice(0, 10);
-        const jsonBlob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+        const jsonBlob = new Blob([JSON.stringify(reportRoot, null, 2)], { type: "application/json" });
         downloadBlob(jsonBlob, `pilot_quick_report_${jobId}_${dateSuffix}.json`);
-        const markdown = buildPilotQuickReportMarkdown(report);
+        const markdown = buildPilotQuickReportMarkdown(reportRoot);
         const mdBlob = new Blob([markdown], { type: "text/markdown" });
         downloadBlob(mdBlob, `pilot_quick_report_${jobId}_${dateSuffix}.md`);
       }

--- a/grantflow/api/routes/jobs.py
+++ b/grantflow/api/routes/jobs.py
@@ -38,10 +38,12 @@ from grantflow.api.public_views import (
     public_job_citations_payload,
     public_job_diff_payload,
     public_job_events_payload,
+    public_job_export_payload,
     public_job_grounding_gate_payload,
     public_job_metrics_payload,
     public_job_payload,
     public_job_quality_payload,
+    public_job_review_workflow_payload,
     public_job_versions_payload,
 )
 from grantflow.api.presets_service import _dispatch_generate_from_preset, _resolve_preflight_request_context
@@ -62,6 +64,7 @@ from grantflow.api.schemas import (
     JobEventsPublicResponse,
     JobGroundingGatePublicResponse,
     JobMetricsPublicResponse,
+    JobPilotQuickReportPublicResponse,
     JobQualitySummaryPublicResponse,
     JobStatusPublicResponse,
     JobVersionsPublicResponse,
@@ -885,6 +888,58 @@ def get_status_quality(job_id: str, request: Request):
     donor = _job_donor_id(job)
     inventory_rows = _ingest_inventory(donor_id=donor or None, tenant_id=job_tenant_id)
     return public_job_quality_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+
+
+@jobs_router.get(
+    "/status/{job_id}/pilot-quick-report",
+    response_model=JobPilotQuickReportPublicResponse,
+    response_model_exclude_none=True,
+)
+def get_status_pilot_quick_report(job_id: str, request: Request):
+    require_api_key_if_configured(request, for_read=True)
+    job = _get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    _ensure_job_tenant_read_access(request, job)
+
+    job = _normalize_critic_fatal_flaws_for_job(job_id) or job
+    job = _maybe_refresh_bid_no_bid_decision(job_id, job)
+    job_tenant_id = _job_tenant_id(job)
+    donor = _job_donor_id(job)
+    inventory_rows = _ingest_inventory(donor_id=donor or None, tenant_id=job_tenant_id)
+
+    metrics_payload = public_job_metrics_payload(job_id, job)
+    quality_payload = public_job_quality_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+    export_payload = public_job_export_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+    workflow_payload = public_job_review_workflow_payload(job_id, job)
+
+    quality_root: Dict[str, Any] = quality_payload if isinstance(quality_payload, dict) else {}
+    metrics_root: Dict[str, Any] = metrics_payload if isinstance(metrics_payload, dict) else {}
+    export_root: Dict[str, Any] = export_payload if isinstance(export_payload, dict) else {}
+    workflow_root: Dict[str, Any] = workflow_payload if isinstance(workflow_payload, dict) else {}
+
+    export_payload_node = export_root.get("payload")
+    export_data: Dict[str, Any] = export_payload_node if isinstance(export_payload_node, dict) else {}
+
+    readiness_node = export_data.get("submission_package_readiness")
+    readiness: Dict[str, Any] = readiness_node if isinstance(readiness_node, dict) else {}
+
+    trust_node = metrics_root.get("grounding_trust_summary")
+    trust: Dict[str, Any] = trust_node if isinstance(trust_node, dict) else {}
+
+    return {
+        "generated_at": _utc_now_iso(),
+        "job_id": job_id,
+        "status": str(job.get("status") or "unknown"),
+        "terminal_status": metrics_root.get("terminal_status"),
+        "quality_score": quality_root.get("quality_score"),
+        "critic_score": quality_root.get("critic_score"),
+        "grounded_trust_score": trust.get("score"),
+        "export_readiness_status": readiness.get("readiness_status"),
+        "export_completeness_score": readiness.get("completeness_score"),
+        "export_top_gap": readiness.get("top_gap"),
+        "review_workflow_summary_present": isinstance(workflow_root.get("summary"), dict),
+    }
 
 
 @jobs_router.post(

--- a/grantflow/api/schemas.py
+++ b/grantflow/api/schemas.py
@@ -1012,6 +1012,22 @@ class JobQualitySummaryPublicResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class JobPilotQuickReportPublicResponse(BaseModel):
+    generated_at: str
+    job_id: str
+    status: str
+    terminal_status: Optional[str] = None
+    quality_score: Optional[float] = None
+    critic_score: Optional[float] = None
+    grounded_trust_score: Optional[float] = None
+    export_readiness_status: Optional[str] = None
+    export_completeness_score: Optional[float] = None
+    export_top_gap: Optional[str] = None
+    review_workflow_summary_present: bool = False
+
+    model_config = ConfigDict(extra="allow")
+
+
 class JobGroundingGatePublicResponse(BaseModel):
     job_id: str
     status: str

--- a/grantflow/api/security.py
+++ b/grantflow/api/security.py
@@ -36,6 +36,7 @@ PROTECTED_OPERATIONS = {
     ("get", "/status/{job_id}/hitl/history/export"),
     ("get", "/status/{job_id}/metrics"),
     ("get", "/status/{job_id}/quality"),
+    ("get", "/status/{job_id}/pilot-quick-report"),
     ("get", "/status/{job_id}/grounding-gate"),
     ("get", "/status/{job_id}/critic"),
     ("get", "/status/{job_id}/critic/findings"),

--- a/grantflow/tests/test_integration.py
+++ b/grantflow/tests/test_integration.py
@@ -14612,6 +14612,31 @@ def test_demo_endpoint_chain_exposes_quality_metrics_and_export_readiness():
     assert submission_readiness.get("top_gap") is not None
 
 
+def test_status_pilot_quick_report_endpoint_exposes_compact_review_snapshot():
+    gen = client.post(
+        "/generate/from-preset",
+        json={
+            "preset_key": "un_agencies_katch_evaluation_kyrgyzstan",
+            "preset_type": "auto",
+            "llm_mode": False,
+            "hitl_enabled": False,
+        },
+    )
+    assert gen.status_code == 200
+    job_id = gen.json()["job_id"]
+    status = _wait_for_terminal_status(job_id)
+    assert status["status"] == "done"
+
+    report = client.get(f"/status/{job_id}/pilot-quick-report")
+    assert report.status_code == 200
+    body = report.json()
+    assert body["job_id"] == job_id
+    assert body["status"] == "done"
+    assert body["export_readiness_status"] in {"ready", "partial", "weak", "missing"}
+    assert body.get("export_top_gap") is not None
+    assert isinstance(body.get("review_workflow_summary_present"), bool)
+
+
 def test_public_export_payload_downgrades_rfq_readiness_when_ready_annex_file_is_missing():
     job = {
         "status": "done",


### PR DESCRIPTION
## Summary
- add API endpoint: `GET /status/{job_id}/pilot-quick-report`
- add schema model for compact pilot report payload
- include endpoint in read-allowed API surface list
- wire Demo `Download Pilot Quick Report` button to use this single endpoint
- add integration coverage for the new endpoint contract

## Why
Next big package: move pilot quick report generation server-side, reduce client fan-out and make report contract stable for UI/ops.

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_integration.py -k "pilot_quick_report_endpoint_exposes_compact_review_snapshot or demo_endpoint_chain_exposes_quality_metrics_and_export_readiness" -q`
- `pytest grantflow/tests/test_demo_ui_triage_smoke.py -q`
