### PR TITLE
feat(exports+ops): pilot quick report export endpoint + UI/script wiring

### DIFF
--- a/docs/pilot-go-no-go-quickcheck.md
+++ b/docs/pilot-go-no-go-quickcheck.md
@@ -11,6 +11,7 @@ make pilot-quickcheck
 Artifacts:
 - `build/pilot-quickcheck/report.json`
 - `build/pilot-quickcheck/report.md`
+- with `JOB_ID`: `build/pilot-quickcheck/report_api.json` + `build/pilot-quickcheck/report_api.md`
 
 ## 1) Runtime up and healthy
 

--- a/grantflow/api/demo_ui.py
+++ b/grantflow/api/demo_ui.py
@@ -8098,14 +8098,28 @@ def render_demo_ui_html() -> str:
       async function downloadPilotQuickReport() {
         const jobId = currentJobId();
         if (!jobId) throw new Error("No job_id");
-        const report = await apiFetch(`/status/${encodeURIComponent(jobId)}/pilot-quick-report`);
-        const reportRoot = report && typeof report === "object" ? report : {};
-        const dateSuffix = new Date().toISOString().slice(0, 10);
-        const jsonBlob = new Blob([JSON.stringify(reportRoot, null, 2)], { type: "application/json" });
-        downloadBlob(jsonBlob, `pilot_quick_report_${jobId}_${dateSuffix}.json`);
-        const markdown = buildPilotQuickReportMarkdown(reportRoot);
-        const mdBlob = new Blob([markdown], { type: "text/markdown" });
-        downloadBlob(mdBlob, `pilot_quick_report_${jobId}_${dateSuffix}.md`);
+
+        const downloadFormat = async (format, fallbackFilename) => {
+          const endpoint = `/status/${encodeURIComponent(jobId)}/pilot-quick-report/export?format=${encodeURIComponent(format)}`;
+          const res = await fetch(`${apiBase()}${endpoint}`, { headers: { ...headers() } });
+          if (!res.ok) {
+            const ct = res.headers.get("content-type") || "";
+            if (ct.includes("application/json")) {
+              const body = await res.json();
+              throw new Error(JSON.stringify(body, null, 2));
+            }
+            throw new Error(await res.text());
+          }
+          const filename = parseDownloadFilenameFromDisposition(
+            res.headers.get("content-disposition"),
+            fallbackFilename
+          );
+          const blob = await res.blob();
+          downloadBlob(blob, filename);
+        };
+
+        await downloadFormat("json", `pilot_quick_report_${jobId}.json`);
+        await downloadFormat("md", `pilot_quick_report_${jobId}.md`);
       }
 
       function applyPortfolioDonorFilter(donorKey) {

--- a/grantflow/api/routes/exports.py
+++ b/grantflow/api/routes/exports.py
@@ -45,6 +45,8 @@ from grantflow.api.public_views import (
     public_job_comments_payload,
     public_job_events_payload,
     public_job_export_payload,
+    public_job_metrics_payload,
+    public_job_quality_payload,
     public_job_review_workflow_csv_text,
     public_job_review_workflow_payload,
     public_job_review_workflow_sla_csv_text,
@@ -1664,6 +1666,114 @@ def get_status_export_payload(job_id: str, request: Request):
     donor = _job_donor_id(job)
     inventory_rows = _ingest_inventory(donor_id=donor or None, tenant_id=job_tenant_id)
     return public_job_export_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+
+
+def _pilot_quick_report_markdown(payload: dict) -> str:
+    lines = [
+        "# Pilot Quick Report",
+        "",
+        f"- generated_at: {str(payload.get('generated_at') or '-')}",
+        f"- job_id: {str(payload.get('job_id') or '-')}",
+        f"- status: {str(payload.get('status') or '-')}",
+        f"- terminal_status: {str(payload.get('terminal_status') or '-')}",
+        "",
+        "## Quality",
+        f"- quality_score: {str(payload.get('quality_score'))}",
+        f"- critic_score: {str(payload.get('critic_score'))}",
+        f"- grounded_trust_score: {str(payload.get('grounded_trust_score'))}",
+        "",
+        "## Export readiness",
+        f"- readiness_status: {str(payload.get('export_readiness_status') or '-')}",
+        f"- completeness_score: {str(payload.get('export_completeness_score'))}",
+        f"- top_gap: {str(payload.get('export_top_gap') or '-')}",
+        "",
+        "## Workflow",
+        f"- summary_present: {str(bool(payload.get('review_workflow_summary_present'))).lower()}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@exports_router.get("/status/{job_id}/pilot-quick-report/export")
+def export_status_pilot_quick_report(
+    job_id: str,
+    request: Request,
+    format: str = Query(default="json"),
+    gzip_enabled: bool = Query(default=False, alias="gzip"),
+):
+    require_api_key_if_configured(request, for_read=True)
+    job = _get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    _ensure_job_tenant_read_access(request, job)
+    job = _normalize_critic_fatal_flaws_for_job(job_id) or job
+
+    job_tenant_id = _job_tenant_id(job)
+    donor = _job_donor_id(job)
+    inventory_rows = _ingest_inventory(donor_id=donor or None, tenant_id=job_tenant_id)
+
+    metrics_payload = public_job_metrics_payload(job_id, job)
+    quality_payload = public_job_quality_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+    export_payload = public_job_export_payload(job_id, job, ingest_inventory_rows=inventory_rows)
+    workflow_payload = public_job_review_workflow_payload(job_id, job)
+
+    metrics_root: dict = metrics_payload if isinstance(metrics_payload, dict) else {}
+    quality_root: dict = quality_payload if isinstance(quality_payload, dict) else {}
+    export_root: dict = export_payload if isinstance(export_payload, dict) else {}
+    workflow_root: dict = workflow_payload if isinstance(workflow_payload, dict) else {}
+
+    export_payload_node = export_root.get("payload")
+    export_data: dict = export_payload_node if isinstance(export_payload_node, dict) else {}
+
+    readiness_node = export_data.get("submission_package_readiness")
+    readiness: dict = readiness_node if isinstance(readiness_node, dict) else {}
+
+    trust_node = metrics_root.get("grounding_trust_summary")
+    trust: dict = trust_node if isinstance(trust_node, dict) else {}
+    report_payload = {
+        "generated_at": metrics_root.get("generated_at") or quality_root.get("generated_at") or "",
+        "job_id": job_id,
+        "status": str(job.get("status") or "unknown"),
+        "terminal_status": metrics_root.get("terminal_status"),
+        "quality_score": quality_root.get("quality_score"),
+        "critic_score": quality_root.get("critic_score"),
+        "grounded_trust_score": trust.get("score"),
+        "export_readiness_status": readiness.get("readiness_status"),
+        "export_completeness_score": readiness.get("completeness_score"),
+        "export_top_gap": readiness.get("top_gap"),
+        "review_workflow_summary_present": isinstance(workflow_root.get("summary"), dict),
+    }
+
+    export_format = str(format or "json").strip().lower()
+    if export_format == "json":
+        return _portfolio_export_response(
+            payload=report_payload,
+            filename_prefix=f"pilot_quick_report_{job_id}",
+            donor_id=None,
+            status=None,
+            hitl_enabled=None,
+            export_format="json",
+            gzip_enabled=gzip_enabled,
+            csv_renderer=lambda _: "",
+        )
+    if export_format == "md":
+        body_text = _pilot_quick_report_markdown(report_payload)
+        body_bytes = body_text.encode("utf-8")
+        extension = "md"
+        media_type = "text/markdown; charset=utf-8"
+        if gzip_enabled:
+            import gzip
+
+            body_bytes = gzip.compress(body_bytes)
+            extension = "md.gz"
+            media_type = "application/gzip"
+        filename = f"pilot_quick_report_{job_id}.{extension}"
+        return StreamingResponse(
+            io.BytesIO(body_bytes),
+            media_type=media_type,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    raise HTTPException(status_code=400, detail="Unsupported format")
 
 
 @exports_router.get("/status/{job_id}/events/export")

--- a/grantflow/api/security.py
+++ b/grantflow/api/security.py
@@ -28,6 +28,7 @@ PROTECTED_OPERATIONS = {
     ("get", "/status/{job_id}"),
     ("get", "/status/{job_id}/citations"),
     ("get", "/status/{job_id}/export-payload"),
+    ("get", "/status/{job_id}/pilot-quick-report/export"),
     ("get", "/status/{job_id}/versions"),
     ("get", "/status/{job_id}/diff"),
     ("get", "/status/{job_id}/events"),

--- a/grantflow/tests/test_integration.py
+++ b/grantflow/tests/test_integration.py
@@ -14637,6 +14637,34 @@ def test_status_pilot_quick_report_endpoint_exposes_compact_review_snapshot():
     assert isinstance(body.get("review_workflow_summary_present"), bool)
 
 
+def test_status_pilot_quick_report_export_supports_json_and_markdown():
+    gen = client.post(
+        "/generate/from-preset",
+        json={
+            "preset_key": "un_agencies_katch_evaluation_kyrgyzstan",
+            "preset_type": "auto",
+            "llm_mode": False,
+            "hitl_enabled": False,
+        },
+    )
+    assert gen.status_code == 200
+    job_id = gen.json()["job_id"]
+    status = _wait_for_terminal_status(job_id)
+    assert status["status"] == "done"
+
+    exported_json = client.get(f"/status/{job_id}/pilot-quick-report/export?format=json")
+    assert exported_json.status_code == 200
+    assert exported_json.headers["content-type"].startswith("application/json")
+    assert "pilot_quick_report" in exported_json.headers.get("content-disposition", "")
+    json_payload = json.loads(exported_json.text)
+    assert json_payload["job_id"] == job_id
+
+    exported_md = client.get(f"/status/{job_id}/pilot-quick-report/export?format=md")
+    assert exported_md.status_code == 200
+    assert exported_md.headers["content-type"].startswith("text/markdown")
+    assert "# Pilot Quick Report" in exported_md.text
+
+
 def test_public_export_payload_downgrades_rfq_readiness_when_ready_annex_file_is_missing():
     job = {
         "status": "done",

--- a/scripts/pilot_quickcheck.sh
+++ b/scripts/pilot_quickcheck.sh
@@ -106,6 +106,8 @@ if [[ -n "$JOB_ID" ]]; then
   printf "[4/4] Job contract spot-check for %s\n" "$JOB_ID"
   curl -fsS "$API_BASE/status/$JOB_ID/quality" | python3 -c 'import json,sys;d=json.load(sys.stdin);s=((d.get("export_contract") or {}).get("submission_readiness_summary") or {});assert s.get("readiness_status") in {"ready","partial","weak","missing"};print("quality_ok")' >/dev/null
   curl -fsS "$API_BASE/status/$JOB_ID/review/workflow" | python3 -c 'import json,sys;d=json.load(sys.stdin);assert isinstance(d.get("summary"),dict);print("workflow_ok")' >/dev/null
+  curl -fsS "$API_BASE/status/$JOB_ID/pilot-quick-report/export?format=json" -o "$REPORT_DIR/report_api.json"
+  curl -fsS "$API_BASE/status/$JOB_ID/pilot-quick-report/export?format=md" -o "$REPORT_DIR/report_api.md"
 fi
 
 echo "pilot_quickcheck: PASS ($REPORT_JSON, $REPORT_MD)"


### PR DESCRIPTION
## Summary
- add `GET /status/{job_id}/pilot-quick-report/export` with `format=json|md` (+ optional `gzip=true`)
- keep payload consistent with pilot quick report endpoint and return attachment headers
- wire Demo `Download Pilot Quick Report` button to download exported JSON+MD from server endpoint
- extend `scripts/pilot_quickcheck.sh` to fetch `report_api.json` + `report_api.md` when `JOB_ID` is provided
- update quickcheck doc artifacts note
- add integration test coverage for `pilot-quick-report/export`

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_integration.py -k pilot_quick_report -q`
- `pytest grantflow/tests/test_demo_ui_triage_smoke.py -q`
