### PR TITLE
feat(exports+ops): add csv pilot quick report export

### DIFF
--- a/docs/pilot-go-no-go-quickcheck.md
+++ b/docs/pilot-go-no-go-quickcheck.md
@@ -29,7 +29,7 @@ Artifacts:
 - `build/pilot-quickcheck/report.json`
 - `build/pilot-quickcheck/report.md`
 - `build/pilot-quickcheck/report.summary.txt`
-- with `JOB_ID` (or `AUTO_JOB=1`): `build/pilot-quickcheck/report_api.json` + `build/pilot-quickcheck/report_api.md`
+- with `JOB_ID` (or `AUTO_JOB=1`): `build/pilot-quickcheck/report_api.json` + `build/pilot-quickcheck/report_api.md` + `build/pilot-quickcheck/report_api.csv`
 
 ## 1) Runtime up and healthy
 

--- a/grantflow/api/routes/exports.py
+++ b/grantflow/api/routes/exports.py
@@ -1694,6 +1694,24 @@ def _pilot_quick_report_markdown(payload: dict) -> str:
     return "\n".join(lines)
 
 
+def _pilot_quick_report_csv(payload: dict) -> str:
+    keys = [
+        "generated_at",
+        "job_id",
+        "status",
+        "terminal_status",
+        "quality_score",
+        "critic_score",
+        "grounded_trust_score",
+        "export_readiness_status",
+        "export_completeness_score",
+        "export_top_gap",
+        "review_workflow_summary_present",
+    ]
+    values = [str(payload.get(k, "")) for k in keys]
+    return ",".join(keys) + "\n" + ",".join(values) + "\n"
+
+
 @exports_router.get("/status/{job_id}/pilot-quick-report/export")
 def export_status_pilot_quick_report(
     job_id: str,
@@ -1745,16 +1763,16 @@ def export_status_pilot_quick_report(
     }
 
     export_format = str(format or "json").strip().lower()
-    if export_format == "json":
+    if export_format in {"json", "csv"}:
         return _portfolio_export_response(
             payload=report_payload,
             filename_prefix=f"pilot_quick_report_{job_id}",
             donor_id=None,
             status=None,
             hitl_enabled=None,
-            export_format="json",
+            export_format="csv" if export_format == "csv" else "json",
             gzip_enabled=gzip_enabled,
-            csv_renderer=lambda _: "",
+            csv_renderer=_pilot_quick_report_csv,
         )
     if export_format == "md":
         body_text = _pilot_quick_report_markdown(report_payload)

--- a/grantflow/tests/test_integration.py
+++ b/grantflow/tests/test_integration.py
@@ -14664,6 +14664,11 @@ def test_status_pilot_quick_report_export_supports_json_and_markdown():
     assert exported_md.headers["content-type"].startswith("text/markdown")
     assert "# Pilot Quick Report" in exported_md.text
 
+    exported_csv = client.get(f"/status/{job_id}/pilot-quick-report/export?format=csv")
+    assert exported_csv.status_code == 200
+    assert exported_csv.headers["content-type"].startswith("text/csv")
+    assert "job_id" in exported_csv.text.splitlines()[0]
+
 
 def test_status_pilot_quick_report_export_supports_gzip_json():
     gen = client.post(

--- a/scripts/pilot_quickcheck.sh
+++ b/scripts/pilot_quickcheck.sh
@@ -222,6 +222,7 @@ if [[ -n "$JOB_ID" ]]; then
   curl -fsS "${HDR[@]}" "$API_BASE/status/$JOB_ID/review/workflow" | python3 -c 'import json,sys;d=json.load(sys.stdin);assert isinstance(d.get("summary"),dict);print("workflow_ok")' >/dev/null
   curl -fsS "${HDR[@]}" "$API_BASE/status/$JOB_ID/pilot-quick-report/export?format=json" -o "$REPORT_DIR/report_api.json"
   curl -fsS "${HDR[@]}" "$API_BASE/status/$JOB_ID/pilot-quick-report/export?format=md" -o "$REPORT_DIR/report_api.md"
+  curl -fsS "${HDR[@]}" "$API_BASE/status/$JOB_ID/pilot-quick-report/export?format=csv" -o "$REPORT_DIR/report_api.csv"
 fi
 
 echo "pilot_quickcheck: PASS ($REPORT_JSON, $REPORT_MD, $REPORT_SUMMARY)"


### PR DESCRIPTION
## Summary
- add CSV support to `GET /status/{job_id}/pilot-quick-report/export` (`format=csv`)
- include CSV artifact download in `scripts/pilot_quickcheck.sh` (`report_api.csv`)
- update pilot quickcheck docs with CSV artifact path
- extend integration coverage to verify CSV export response

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_integration.py -k "pilot_quick_report_export_supports_json_and_markdown or pilot_quick_report_export_rejects_unsupported_format" -q`
