### PR TITLE
feat(demo+exports): csv quick report download + gzip csv test

### DIFF
--- a/grantflow/api/demo_ui.py
+++ b/grantflow/api/demo_ui.py
@@ -8120,6 +8120,7 @@ def render_demo_ui_html() -> str:
 
         await downloadFormat("json", `pilot_quick_report_${jobId}.json`);
         await downloadFormat("md", `pilot_quick_report_${jobId}.md`);
+        await downloadFormat("csv", `pilot_quick_report_${jobId}.csv`);
       }
 
       function applyPortfolioDonorFilter(donorKey) {

--- a/grantflow/tests/test_integration.py
+++ b/grantflow/tests/test_integration.py
@@ -14716,6 +14716,29 @@ def test_status_pilot_quick_report_export_supports_gzip_markdown():
     assert "# Pilot Quick Report" in markdown
 
 
+def test_status_pilot_quick_report_export_supports_gzip_csv():
+    gen = client.post(
+        "/generate/from-preset",
+        json={
+            "preset_key": "un_agencies_katch_evaluation_kyrgyzstan",
+            "preset_type": "auto",
+            "llm_mode": False,
+            "hitl_enabled": False,
+        },
+    )
+    assert gen.status_code == 200
+    job_id = gen.json()["job_id"]
+    status = _wait_for_terminal_status(job_id)
+    assert status["status"] == "done"
+
+    exported_gz = client.get(f"/status/{job_id}/pilot-quick-report/export?format=csv&gzip=true")
+    assert exported_gz.status_code == 200
+    assert exported_gz.headers["content-type"].startswith("application/gzip")
+    assert exported_gz.headers.get("content-disposition", "").endswith(".csv.gz\"")
+    csv_text = gzip.decompress(exported_gz.content).decode("utf-8")
+    assert "job_id" in csv_text.splitlines()[0]
+
+
 def test_status_pilot_quick_report_export_rejects_unsupported_format():
     gen = client.post(
         "/generate/from-preset",


### PR DESCRIPTION
## Summary
- Demo quick report download now also fetches CSV export
- add integration coverage for gzip CSV export (`format=csv&gzip=true`)

## Verification
- `make qa-fast`
- `pytest grantflow/tests/test_integration.py -k "pilot_quick_report_export_supports_gzip_markdown or pilot_quick_report_export_supports_gzip_csv" -q`
- `pytest grantflow/tests/test_demo_ui_triage_smoke.py -q`
