### PR TITLE
chore(ci): upgrade GitHub Actions to Node24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -35,7 +35,7 @@ jobs:
   shell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install shellcheck
         run: |
@@ -56,10 +56,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -70,10 +70,10 @@ jobs:
   dependency-contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -97,10 +97,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -124,10 +124,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -145,10 +145,10 @@ jobs:
   prod-preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -189,10 +189,10 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       GRANTFLOW_FORCE_INMEM_VECTOR_STORE: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -297,7 +297,7 @@ jobs:
             --out eval-artifacts/grounded-gate-summary.md
 
       - name: Upload evaluation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: eval-report
@@ -309,10 +309,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -470,7 +470,7 @@ jobs:
           PY
 
       - name: Upload grounded smoke artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: grounded-smoke-artifacts
@@ -483,10 +483,10 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       GRANTFLOW_FORCE_INMEM_VECTOR_STORE: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -536,7 +536,7 @@ jobs:
           fi
 
       - name: Upload demo smoke artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: demo-smoke-artifacts
@@ -551,7 +551,7 @@ jobs:
   docker-compose-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run docker-compose smoke (/ready + redis worker heartbeat + /generate llm_mode=false)
         run: |
@@ -562,10 +562,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -586,10 +586,10 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -616,7 +616,7 @@ jobs:
           make test-e2e
 
       - name: Upload coverage (optional)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: coverage-report

--- a/.github/workflows/llm-eval-grounded-strict.yml
+++ b/.github/workflows/llm-eval-grounded-strict.yml
@@ -49,10 +49,10 @@ jobs:
       CHROMA_PORT: ${{ vars.CHROMA_PORT }}
       CHROMA_COLLECTION_PREFIX: ${{ vars.CHROMA_COLLECTION_PREFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Upload grounded strict LLM evaluation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: llm-eval-grounded-strict-report

--- a/.github/workflows/llm-eval-grounded.yml
+++ b/.github/workflows/llm-eval-grounded.yml
@@ -52,10 +52,10 @@ jobs:
       CHROMA_PORT: ${{ vars.CHROMA_PORT }}
       CHROMA_COLLECTION_PREFIX: ${{ vars.CHROMA_COLLECTION_PREFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -130,7 +130,7 @@ jobs:
           cat llm-eval-grounded-artifacts/llm-eval-grounded-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload grounded LLM evaluation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: llm-eval-grounded-report

--- a/.github/workflows/llm-eval.yml
+++ b/.github/workflows/llm-eval.yml
@@ -20,10 +20,10 @@ jobs:
       OPENROUTER_HTTP_REFERER: ${{ vars.OPENROUTER_HTTP_REFERER }}
       OPENROUTER_X_TITLE: ${{ vars.OPENROUTER_X_TITLE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -50,7 +50,7 @@ jobs:
             --json-out llm-eval-artifacts/llm-eval-report.json
 
       - name: Upload LLM evaluation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: llm-eval-report

--- a/.github/workflows/nightly-grounded-tail.yml
+++ b/.github/workflows/nightly-grounded-tail.yml
@@ -19,10 +19,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -109,7 +109,7 @@ jobs:
             --body "Automated alert: nightly grounded tail failed 2 runs in a row. Please triage latest run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Upload grounded tail evaluation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: grounded-tail-eval-report

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -35,12 +35,12 @@ jobs:
       tag_name: ${{ steps.resolve.outputs.tag_name }}
       target_commitish: ${{ steps.resolve.outputs.target_commitish }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -99,7 +99,7 @@ jobs:
     environment:
       name: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve release tag
         id: tag

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -18,9 +18,9 @@ jobs:
   audit-and-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
           cyclonedx-py requirements -i requirements.lock -o sbom.cdx.json
 
       - name: Upload supply-chain artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: supply-chain-artifacts

--- a/.github/workflows/synthetic-alert-delivery-check.yml
+++ b/.github/workflows/synthetic-alert-delivery-check.yml
@@ -9,7 +9,7 @@ jobs:
   synthetic-alert-delivery:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify alert webhook is configured
         env:


### PR DESCRIPTION
Replaces legacy action majors to remove Node20 deprecation noise on GitHub-hosted runners:\n- actions/checkout v4 -> v5\n- actions/setup-python v5 -> v6\n- actions/upload-artifact v4 -> v5