### PR TITLE
chore(deps): add Dependabot for actions and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Almaty"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:10"
+      timezone: "Asia/Almaty"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Adds weekly Dependabot updates for:\n- GitHub Actions workflow dependencies\n- Python dependencies (pip / pyproject at repo root)\n\nSchedule: Mondays (Asia/Almaty).