### PR TITLE
chore(ci): add Dependabot auto-merge and CI maintenance guide

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,50 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether update is patch/minor
+        id: semver
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+
+          title = os.environ.get("PR_TITLE", "")
+          m = re.search(r" from ([0-9]+(?:\.[0-9]+){0,2}) to ([0-9]+(?:\.[0-9]+){0,2})", title)
+          ok = False
+          if m:
+              old = [int(x) for x in m.group(1).split(".")]
+              new = [int(x) for x in m.group(2).split(".")]
+              while len(old) < 3:
+                  old.append(0)
+              while len(new) < 3:
+                  new.append(0)
+              if new[0] == old[0] and (new[1] > old[1] or (new[1] == old[1] and new[2] >= old[2])):
+                  ok = True
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+              f.write(f"allow={str(ok).lower()}\n")
+          PY
+
+      - name: Enable auto-merge (squash) for safe updates
+        if: steps.semver.outputs.allow == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
+
+      - name: Skip major or non-semver update
+        if: steps.semver.outputs.allow != 'true'
+        run: echo "Skip auto-merge: major or unrecognized version bump format"

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ If you are new to the project, read in this order:
 - `full-guide.md`
 - `git-process.md`
 - `release-process.md`
+- `ci-maintenance.md`
 
 ---
 

--- a/docs/ci-maintenance.md
+++ b/docs/ci-maintenance.md
@@ -1,0 +1,27 @@
+# CI Maintenance
+
+## Update policy
+
+- Dependabot creates weekly update PRs for GitHub Actions and pip dependencies.
+- Patch/minor Dependabot updates are auto-merged after required checks pass.
+- Major updates are left for manual review.
+
+## If CI fails on a dependency PR
+
+1. Open failed job log (`gh pr checks <pr-number>`).
+2. Fix forward in the dependency PR branch if change is safe.
+3. If unsafe, close the PR and pin version explicitly in `pyproject.toml`/workflow.
+
+## Manual CI trigger
+
+Use workflow_dispatch when PR event CI is stale or needs a clean rerun:
+
+```bash
+gh workflow run CI --ref <branch>
+```
+
+Then verify:
+
+```bash
+gh pr checks <pr-number>
+```


### PR DESCRIPTION
Adds:\n- Dependabot auto-merge workflow for safe patch/minor updates after checks pass\n- docs/ci-maintenance.md runbook\n- docs map link to CI maintenance guide