### PR TITLE
chore(ci): add docs-only path filter for pull_request CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
 
 concurrency:

--- a/docs/ci-maintenance.md
+++ b/docs/ci-maintenance.md
@@ -12,6 +12,11 @@
 2. Fix forward in the dependency PR branch if change is safe.
 3. If unsafe, close the PR and pin version explicitly in `pyproject.toml`/workflow.
 
+## Docs-only PR fast-path
+
+- `CI` workflow is skipped for pull requests that touch only `docs/**` and `*.md` files.
+- Use `workflow_dispatch` if you still want a full CI run on a docs-only branch.
+
 ## Manual CI trigger
 
 Use workflow_dispatch when PR event CI is stale or needs a clean rerun:


### PR DESCRIPTION
Skips full CI workflow for pull requests that only touch docs/markdown files to reduce unnecessary CI load.\n\nAlso updates docs/ci-maintenance.md with behavior and manual override via workflow_dispatch.