### PR TITLE
docs(product): focus ICP and add pilot success metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Built for governed drafting and review workflows — not a generic grant-writing
 - traceability for findings, citations, versions, and events
 - export-ready `.docx`, `.xlsx`, and ZIP deliverables
 
-### Who it is for
-- NGOs and implementing organizations
-- consulting firms managing donor submissions
-- program and MEL teams running institutional compliance workflows
+### Who it is for (current wedge)
+- NGOs and implementing organizations preparing institutional donor proposals
+- proposal managers and MEL leads who need governed drafting with auditability
+
+### Primary use case (now)
+- turn one funding opportunity + internal program inputs into a review-ready draft package with checkpoints and exports
 
 ### What it is not
 - a general-purpose grant-writing chatbot
@@ -94,6 +96,7 @@ Expected outputs:
 Start here:
 - `docs/buyer-one-pager.md`
 - `docs/five-minute-demo.md`
+- `docs/pilot-success-metrics.md`
 - `docs/samples/`
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ If you are new to the project, read in this order:
 - `oem-one-pager.md`
 - `five-minute-demo.md`
 - `proof-summary.md`
+- `pilot-success-metrics.md`
 - `production-boundaries.md`
 
 ---

--- a/docs/pilot-success-metrics.md
+++ b/docs/pilot-success-metrics.md
@@ -1,0 +1,45 @@
+# Pilot Success Metrics (12-week baseline)
+
+Use this as the default scorecard for buyer pilots.
+
+## Scope
+
+- ICP: NGOs / implementing orgs preparing institutional donor proposals
+- Workflow: one live opportunity from intake to review-ready package
+
+## Primary outcomes (must-have)
+
+1. Cycle time reduction
+   - Target: 30-50% faster draft package preparation vs baseline
+2. Review loop reduction
+   - Target: 20-40% fewer major revision rounds before submission-ready state
+3. Compliance completeness
+   - Target: >=95% required sections/checklist fields present at first formal review
+4. Traceability coverage
+   - Target: >=90% critical claims linked to source/citation/event trace
+
+## Secondary outcomes (nice-to-have)
+
+- Reviewer time saved: 15-30%
+- Export/package preparation time: 40-60% faster
+- Fewer late-stage structural rewrites
+
+## Evidence to collect weekly
+
+- median lead time: intake -> first review-ready package
+- number of major revision rounds per package
+- checklist completeness score at first review
+- traceability coverage score (critical claims)
+- qualitative notes from proposal manager + MEL lead
+
+## Go / No-Go gate (pilot end)
+
+Go if all are true:
+- at least 2/4 primary outcomes hit target range
+- no severe governance/compliance incident
+- pilot team requests expansion to next donor/workstream
+
+No-Go if any are true:
+- cycle time worsens for 3+ consecutive weeks
+- compliance completeness remains <85%
+- traceability repeatedly fails on critical sections


### PR DESCRIPTION
Tightens product focus in README and adds a measurable pilot scorecard.\n\nChanges:\n- narrows current wedge/ICP wording in README\n- adds explicit primary use case\n- adds docs/pilot-success-metrics.md with 12-week KPI ranges and go/no-go gates\n- links new metrics doc from README and docs map